### PR TITLE
Make QR copy interactions keyboard-accessible

### DIFF
--- a/apps/web-app/src/App.css
+++ b/apps/web-app/src/App.css
@@ -773,6 +773,24 @@ button.settings-link:hover {
   cursor: pointer;
 }
 
+button.qr-copy-button {
+  background: transparent;
+  border: none;
+  display: block;
+  margin: 12px auto 0;
+  padding: 0;
+}
+
+button.qr-copy-button .qr {
+  margin: 0;
+}
+
+button.qr-copy-button:focus-visible {
+  border-radius: 12px;
+  outline: 2px solid #38bdf8;
+  outline-offset: 4px;
+}
+
 .profile-detail {
   display: flex;
   flex-direction: column;

--- a/apps/web-app/src/pages/ProfilePage.tsx
+++ b/apps/web-app/src/pages/ProfilePage.tsx
@@ -214,15 +214,18 @@ export function ProfilePage({
                 </div>
 
                 {myProfileQr ? (
-                  <img
-                    className="qr"
-                    src={myProfileQr}
-                    alt=""
+                  <button
+                    type="button"
+                    className="qr-copy-button"
                     onClick={() => {
                       if (!currentNpub) return;
                       void copyText(currentNpub);
                     }}
-                  />
+                    aria-label={t("copy")}
+                    title={t("copy")}
+                  >
+                    <img className="qr" src={myProfileQr} alt="" />
+                  </button>
                 ) : (
                   <p className="muted">{currentNpub}</p>
                 )}

--- a/apps/web-app/src/pages/TopupInvoicePage.tsx
+++ b/apps/web-app/src/pages/TopupInvoicePage.tsx
@@ -43,15 +43,18 @@ export const TopupInvoicePage: FC<TopupInvoicePageProps> = ({
       )}
 
       {topupInvoiceQr ? (
-        <img
-          className="qr"
-          src={topupInvoiceQr}
-          alt=""
+        <button
+          type="button"
+          className="qr-copy-button"
           onClick={() => {
             if (!topupInvoice) return;
             void copyText(topupInvoice);
           }}
-        />
+          aria-label={t("copy")}
+          title={t("copy")}
+        >
+          <img className="qr" src={topupInvoiceQr} alt="" />
+        </button>
       ) : topupInvoiceError ? (
         <p className="muted">{topupInvoiceError}</p>
       ) : topupInvoice ? (


### PR DESCRIPTION
Closes #22

## Summary
- replaced clickable QR `<img>` elements with semantic `<button type="button">` wrappers in `ProfilePage` and `TopupInvoicePage`
- preserved existing copy behavior by keeping the same `copyText(...)` handlers
- added shared `button.qr-copy-button` styles in `App.css` (transparent button reset + focus-visible outline) while reusing existing `.qr` image styling

## Validation
- `bun run check-code`