### PR TITLE
Make user's npub text copyable in profile overlay

### DIFF
--- a/apps/web-app/src/App.css
+++ b/apps/web-app/src/App.css
@@ -1995,9 +1995,9 @@ button.copyable {
 button.copyable.npub {
   display: block;
   max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: break-word;
+  word-break: break-all;
+  text-align: center;
 }
 
 button.copyable:hover {
@@ -2071,7 +2071,7 @@ button.tag-button {
   position: fixed;
   top: 70px;
   right: 12px;
-  z-index: 60;
+  z-index: 100;
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/apps/web-app/src/app/context/AppShellContexts.tsx
+++ b/apps/web-app/src/app/context/AppShellContexts.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import React from "react";
-import type { Lang } from "../../i18n";
+import type { I18nKey, Lang } from "../../i18n";
 import type { Route } from "../../types/route";
 import type { DerivedProfileDefaults } from "../../derivedProfile";
 import type {
@@ -77,7 +77,7 @@ export interface AppShellActionsContextValue {
     back: () => void;
     next: () => void;
   };
-  copyText: (text: string) => Promise<void>;
+  copyText: (text: string, successToastKey?: I18nKey) => Promise<void>;
   onPickProfilePhoto: () => void;
   onProfilePhotoSelected: (event: React.ChangeEvent<HTMLInputElement>) => void;
   openFeedbackContact: () => void;

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -17,7 +17,7 @@ import {
 } from "../evolu";
 import { navigateTo, useRouting } from "../hooks/useRouting";
 import { useToasts } from "../hooks/useToasts";
-import { getInitialLang, translations, type Lang } from "../i18n";
+import { getInitialLang, translations, type I18nKey, type Lang } from "../i18n";
 import { type NostrProfileMetadata } from "../nostrProfile";
 import { getCashuDeterministicSeedFromStorage } from "../utils/cashuDeterministic";
 import { getCashuLib } from "../utils/cashuLib";
@@ -1609,10 +1609,17 @@ export const useAppShellComposition = () => {
     update,
   });
 
-  const copyText = async (value: string) => {
+  const copyText = async (
+    value: string,
+    successToastKey: I18nKey = "copiedToClipboard",
+  ) => {
     try {
-      await navigator.clipboard?.writeText(value);
-      pushToast(t("copiedToClipboard"));
+      const writeText = navigator.clipboard?.writeText;
+      if (!writeText) {
+        throw new Error("Clipboard API unavailable");
+      }
+      await writeText.call(navigator.clipboard, value);
+      pushToast(t(successToastKey));
     } catch {
       pushToast(t("copyFailed"));
     }

--- a/apps/web-app/src/components/AuthenticatedLayout.tsx
+++ b/apps/web-app/src/components/AuthenticatedLayout.tsx
@@ -87,7 +87,7 @@ export function AuthenticatedLayout({
           onClose={actions.closeProfileQr}
           onCopyNpub={() => {
             if (!state.currentNpub) return;
-            void actions.copyText(state.currentNpub);
+            void actions.copyText(state.currentNpub, "yourNpubWasCopied");
           }}
           onPickProfilePhoto={actions.onPickProfilePhoto}
           onProfilePhotoSelected={actions.onProfilePhotoSelected}

--- a/apps/web-app/src/components/ProfileQrModal.tsx
+++ b/apps/web-app/src/components/ProfileQrModal.tsx
@@ -266,17 +266,23 @@ export function ProfileQrModal({
                 alt=""
                 onClick={onCopyNpub}
               />
-            ) : (
-              <p className="muted">{currentNpub}</p>
-            )}
+            ) : null}
 
             <h2 className="contact-detail-name">
               {effectiveProfileName ?? formatShortNpub(currentNpub)}
             </h2>
 
-            {effectiveMyLightningAddress ? (
-              <p className="contact-detail-ln">{effectiveMyLightningAddress}</p>
-            ) : null}
+            {effectiveMyLightningAddress && (
+              <button
+                type="button"
+                className="copyable npub muted"
+                onClick={onCopyNpub}
+                title={t("copy")}
+                aria-label={t("copy")}
+              >
+                {effectiveMyLightningAddress}
+              </button>
+            )}
 
             <p className="muted profile-note">{t("profileMessagesHint")}</p>
           </div>

--- a/apps/web-app/src/components/ToastNotifications.tsx
+++ b/apps/web-app/src/components/ToastNotifications.tsx
@@ -40,7 +40,11 @@ export const ToastNotifications: React.FC<ToastNotificationsProps> = ({
               if (!token) return;
               void (async () => {
                 try {
-                  await navigator.clipboard?.writeText(token);
+                  const writeText = navigator.clipboard?.writeText;
+                  if (!writeText) {
+                    throw new Error("Clipboard API unavailable");
+                  }
+                  await writeText.call(navigator.clipboard, token);
                   pushToast(t("copiedToClipboard"));
                   setRecentlyReceivedToken(null);
                 } catch {

--- a/apps/web-app/src/i18n/cs.ts
+++ b/apps/web-app/src/i18n/cs.ts
@@ -309,6 +309,7 @@ export const cs = {
   contactDeleted: "Kontakt byl smazán.",
 
   copiedToClipboard: "Zkopírováno do schránky.",
+  yourNpubWasCopied: "Váš npub byl zkopírován.",
   copyFailed: "Kopírování do schránky se nepovedlo.",
   copy: "Kopírovat",
 

--- a/apps/web-app/src/i18n/en.ts
+++ b/apps/web-app/src/i18n/en.ts
@@ -308,6 +308,7 @@ export const en = {
   contactDeleted: "Contact deleted.",
 
   copiedToClipboard: "Copied to clipboard.",
+  yourNpubWasCopied: "Your npub was copied.",
   copyFailed: "Copy to clipboard failed.",
   copy: "Copy",
 


### PR DESCRIPTION
Closes #24

## Summary
- Make the npub text in profile overlay explicitly clickable using a semantic button.
- Extend the shared copy action to accept a custom success toast key.
- Show a dedicated toast on profile npub copy: "Your npub was copied."
- Add locale translations for the new toast key in all supported locales (`en`, `cs`).
