### PR TITLE
perf(cashu): cache wallet across topup-claim ticks

### DIFF
--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -2143,6 +2143,12 @@ export const useAppShellComposition = () => {
     let cancelled = false;
     let claimInFlight = false;
     let lastLoggedClaimError = "";
+    // Cache the loaded wallet across the 5s polling ticks within this
+    // effect mount. Each tick only does a `checkMintQuote` + the eventual
+    // mintProofs, neither of which needs a fresh `loadMint()`. The effect
+    // tears down when topupMintQuote changes, so the cache is naturally
+    // scoped to one quote / one mintUrl+unit pair.
+    let cachedWallet: LoadedCashuWallet | null = null;
     const run = async () => {
       if (claimInFlight) return;
       claimInFlight = true;
@@ -2227,14 +2233,18 @@ export const useAppShellComposition = () => {
               return;
             }
 
-            const det = getCashuDeterministicSeedFromStorage();
-            const wallet = await createLoadedCashuWallet({
-              CashuMint,
-              CashuWallet,
-              mintUrl: topupMintQuote.mintUrl,
-              ...(topupMintQuote.unit ? { unit: topupMintQuote.unit } : {}),
-              ...(det ? { bip39seed: det.bip39seed } : {}),
-            });
+            let wallet = cachedWallet;
+            if (!wallet) {
+              const det = getCashuDeterministicSeedFromStorage();
+              wallet = await createLoadedCashuWallet({
+                CashuMint,
+                CashuWallet,
+                mintUrl: topupMintQuote.mintUrl,
+                ...(topupMintQuote.unit ? { unit: topupMintQuote.unit } : {}),
+                ...(det ? { bip39seed: det.bip39seed } : {}),
+              });
+              cachedWallet = wallet;
+            }
 
             const status = await wallet.checkMintQuote(quoteId);
             const quoteState = readMintQuoteState(status);


### PR DESCRIPTION
Receive-quote claim effect (5s tick + focus/visibility/online/pageshow triggers) was calling createLoadedCashuWallet on every run, which internally does loadMint() = GET /v1/info + /v1/keysets + /v1/keys/<id>. For a paid invoice that takes ~30s to settle through Lightning, that's 6+ wasted round-trips per quote on top of the actually needed GET /v1/mint/quote/bolt11/<id> poll.

Add a closure-scoped `cachedWallet` inside the effect — the 5s ticks and event-driven runs all share it, the effect tears down when topupMintQuote changes so the cache is naturally scoped to a single quote.

Mirrors the same optimization already done for the autoswap claim effect (autoswapClaimWalletCacheRef in 3e4f167).