### PR TITLE
feat(cashu): detect recipient-claimed issued tokens (closes #86)

### DIFF
--- a/apps/web-app/src/app/hooks/cashu/useCashuTokenChecks.ts
+++ b/apps/web-app/src/app/hooks/cashu/useCashuTokenChecks.ts
@@ -699,13 +699,19 @@ export const useCashuTokenChecks = ({
   // consume proofs, so calling it on issued tokens is safe ("without
   // ruining it"). Groups tokens by mint+unit so we only loadMint once per
   // mint and batch one /v1/checkstate per group.
+  //
+  // Critically this helper does NOT toggle cashuIsBusy /
+  // cashuBulkCheckIsBusy — it's a passive read that runs in the
+  // background and must not disable the rest of the cashu UI (issue,
+  // melt-to-mint, restore-tokens, etc.). A local in-flight ref keeps
+  // concurrent self-calls (button spam + background tick) idempotent.
+  const checkIssuedInFlightRef = React.useRef(false);
   const checkIssuedCashuTokensAndDeleteClaimed =
     React.useCallback(async (): Promise<{
       checked: number;
       claimed: number;
     }> => {
-      if (cashuBulkCheckIsBusy) return { checked: 0, claimed: 0 };
-      if (cashuIsBusy) return { checked: 0, claimed: 0 };
+      if (checkIssuedInFlightRef.current) return { checked: 0, claimed: 0 };
 
       // Group issued tokens by source mint+unit so each group needs only
       // one wallet load + one /v1/checkstate round-trip.
@@ -753,9 +759,7 @@ export const useCashuTokenChecks = ({
 
       if (groups.size === 0) return { checked: 0, claimed: 0 };
 
-      setCashuBulkCheckIsBusy(true);
-      setCashuIsBusy(true);
-
+      checkIssuedInFlightRef.current = true;
       let checkedCount = 0;
       let claimedCount = 0;
 
@@ -839,19 +843,11 @@ export const useCashuTokenChecks = ({
           }
         }
       } finally {
-        setCashuIsBusy(false);
-        setCashuBulkCheckIsBusy(false);
+        checkIssuedInFlightRef.current = false;
       }
 
       return { checked: checkedCount, claimed: claimedCount };
-    }, [
-      cashuBulkCheckIsBusy,
-      cashuIsBusy,
-      cashuTokensAll,
-      setCashuBulkCheckIsBusy,
-      setCashuIsBusy,
-      updateCashuToken,
-    ]);
+    }, [cashuTokensAll, updateCashuToken]);
 
   // Same NUT-07 check as the bulk variant but scoped to a single issued
   // token row — used by the issued-token detail page to poll while the

--- a/apps/web-app/src/app/hooks/cashu/useCashuTokenChecks.ts
+++ b/apps/web-app/src/app/hooks/cashu/useCashuTokenChecks.ts
@@ -86,29 +86,32 @@ export const useCashuTokenChecks = ({
   t,
   update,
 }: UseCashuTokenChecksParams) => {
-  // Wallet cache shared by the issued-claim helpers (bulk + single-token).
-  // `createLoadedCashuWallet` does loadMint() = GET /v1/info + /v1/keysets
-  // + /v1/keys/<id> internally; without caching, the background 60s tick,
-  // the 10s detail-page poll, and the on-mount auto-check each pay that
-  // 3-call tax on every tick. Keyed by `${mintUrl}|${unit}`; cleared on
-  // hook unmount (logout / shell teardown).
+  // Hook-level wallet cache shared by ALL check paths: bulk
+  // `checkAllCashuTokensAndDeleteInvalid`, single-token
+  // `checkAndRefreshCashuToken`, issued-claim bulk +
+  // single-token. `createLoadedCashuWallet` does
+  // loadMint() = GET /v1/info + /v1/keysets + /v1/keys/<id> internally;
+  // without caching, every retry / interval pays that 3-call tax. Keyed
+  // by `${mintUrl}|${unit}`; cleared on hook unmount (logout / shell
+  // teardown). Wallets are read-only here (NUT-07 checkstate / metadata
+  // for token decode), so sharing across operations is safe.
   type LoadedCashuWallet = Awaited<ReturnType<typeof createLoadedCashuWallet>>;
-  const issuedClaimWalletCacheRef = React.useRef<
-    Map<string, LoadedCashuWallet>
-  >(new Map());
+  const cashuWalletCacheRef = React.useRef<Map<string, LoadedCashuWallet>>(
+    new Map(),
+  );
   React.useEffect(() => {
-    const cache = issuedClaimWalletCacheRef.current;
+    const cache = cashuWalletCacheRef.current;
     return () => {
       cache.clear();
     };
   }, []);
-  const loadIssuedClaimWallet = React.useCallback(
+  const loadCachedCashuWallet = React.useCallback(
     async (args: {
       mintUrl: string;
       unit: string;
     }): Promise<LoadedCashuWallet> => {
       const key = `${args.mintUrl}|${args.unit}`;
-      const cached = issuedClaimWalletCacheRef.current.get(key);
+      const cached = cashuWalletCacheRef.current.get(key);
       if (cached) return cached;
       const { CashuMint, CashuWallet } = await getCashuLib();
       const det = getCashuDeterministicSeedFromStorage();
@@ -119,7 +122,7 @@ export const useCashuTokenChecks = ({
         unit: args.unit,
         ...(det ? { bip39seed: det.bip39seed } : {}),
       });
-      issuedClaimWalletCacheRef.current.set(key, wallet);
+      cashuWalletCacheRef.current.set(key, wallet);
       return wallet;
     },
     [],
@@ -342,13 +345,8 @@ export const useCashuTokenChecks = ({
           }
         }
 
-        const {
-          CashuMint,
-          CashuWallet,
-          getDecodedToken,
-          getEncodedToken,
-          getTokenMetadata,
-        } = await getCashuLib();
+        const { getDecodedToken, getEncodedToken, getTokenMetadata } =
+          await getCashuLib();
 
         const tokenMetadata = getTokenMetadata(tokenText);
         const mint = String(tokenMetadata.mint ?? primaryRow.mint ?? "").trim();
@@ -356,14 +354,7 @@ export const useCashuTokenChecks = ({
 
         const unit =
           String(tokenMetadata.unit ?? primaryRow.unit ?? "").trim() || "sat";
-        const det = getCashuDeterministicSeedFromStorage();
-        const wallet = await createLoadedCashuWallet({
-          CashuMint,
-          CashuWallet,
-          mintUrl: mint,
-          ...(unit ? { unit } : {}),
-          ...(det ? { bip39seed: det.bip39seed } : {}),
-        });
+        const wallet = await loadCachedCashuWallet({ mintUrl: mint, unit });
 
         const decoded = decodeCashuTokenForMint({
           tokenText,
@@ -637,7 +628,15 @@ export const useCashuTokenChecks = ({
         }
       }
     },
-    [cashuIsBusy, pushToast, setCashuIsBusy, setStatus, t, updateCashuToken],
+    [
+      cashuIsBusy,
+      loadCachedCashuWallet,
+      pushToast,
+      setCashuIsBusy,
+      setStatus,
+      t,
+      updateCashuToken,
+    ],
   );
 
   const checkAndRefreshCashuToken = React.useCallback(
@@ -804,7 +803,7 @@ export const useCashuTokenChecks = ({
         for (const group of groups.values()) {
           let wallet: LoadedCashuWallet;
           try {
-            wallet = await loadIssuedClaimWallet({
+            wallet = await loadCachedCashuWallet({
               mintUrl: group.mintUrl,
               unit: group.unit,
             });
@@ -889,7 +888,7 @@ export const useCashuTokenChecks = ({
       }
 
       return { checked: checkedCount, claimed };
-    }, [cashuTokensAll, loadIssuedClaimWallet, updateCashuToken]);
+    }, [cashuTokensAll, loadCachedCashuWallet, updateCashuToken]);
 
   // Same NUT-07 check as the bulk variant but scoped to a single issued
   // token row — used by the issued-token detail page to poll while the
@@ -913,7 +912,7 @@ export const useCashuTokenChecks = ({
 
       let wallet: LoadedCashuWallet;
       try {
-        wallet = await loadIssuedClaimWallet({ mintUrl, unit });
+        wallet = await loadCachedCashuWallet({ mintUrl, unit });
       } catch {
         return false;
       }
@@ -965,7 +964,7 @@ export const useCashuTokenChecks = ({
       });
       return result.ok;
     },
-    [cashuTokensAll, loadIssuedClaimWallet, updateCashuToken],
+    [cashuTokensAll, loadCachedCashuWallet, updateCashuToken],
   );
 
   return {

--- a/apps/web-app/src/app/hooks/cashu/useCashuTokenChecks.ts
+++ b/apps/web-app/src/app/hooks/cashu/useCashuTokenChecks.ts
@@ -86,6 +86,45 @@ export const useCashuTokenChecks = ({
   t,
   update,
 }: UseCashuTokenChecksParams) => {
+  // Wallet cache shared by the issued-claim helpers (bulk + single-token).
+  // `createLoadedCashuWallet` does loadMint() = GET /v1/info + /v1/keysets
+  // + /v1/keys/<id> internally; without caching, the background 60s tick,
+  // the 10s detail-page poll, and the on-mount auto-check each pay that
+  // 3-call tax on every tick. Keyed by `${mintUrl}|${unit}`; cleared on
+  // hook unmount (logout / shell teardown).
+  type LoadedCashuWallet = Awaited<ReturnType<typeof createLoadedCashuWallet>>;
+  const issuedClaimWalletCacheRef = React.useRef<
+    Map<string, LoadedCashuWallet>
+  >(new Map());
+  React.useEffect(() => {
+    const cache = issuedClaimWalletCacheRef.current;
+    return () => {
+      cache.clear();
+    };
+  }, []);
+  const loadIssuedClaimWallet = React.useCallback(
+    async (args: {
+      mintUrl: string;
+      unit: string;
+    }): Promise<LoadedCashuWallet> => {
+      const key = `${args.mintUrl}|${args.unit}`;
+      const cached = issuedClaimWalletCacheRef.current.get(key);
+      if (cached) return cached;
+      const { CashuMint, CashuWallet } = await getCashuLib();
+      const det = getCashuDeterministicSeedFromStorage();
+      const wallet = await createLoadedCashuWallet({
+        CashuMint,
+        CashuWallet,
+        mintUrl: args.mintUrl,
+        unit: args.unit,
+        ...(det ? { bip39seed: det.bip39seed } : {}),
+      });
+      issuedClaimWalletCacheRef.current.set(key, wallet);
+      return wallet;
+    },
+    [],
+  );
+
   const updateCashuToken = React.useCallback(
     function (
       payload: CashuTokenUpdatePayload,
@@ -709,9 +748,9 @@ export const useCashuTokenChecks = ({
   const checkIssuedCashuTokensAndDeleteClaimed =
     React.useCallback(async (): Promise<{
       checked: number;
-      claimed: number;
+      claimed: Array<{ id: CashuTokenId; amount: number }>;
     }> => {
-      if (checkIssuedInFlightRef.current) return { checked: 0, claimed: 0 };
+      if (checkIssuedInFlightRef.current) return { checked: 0, claimed: [] };
 
       // Group issued tokens by source mint+unit so each group needs only
       // one wallet load + one /v1/checkstate round-trip.
@@ -728,9 +767,7 @@ export const useCashuTokenChecks = ({
         }
       >();
 
-      const { CashuMint, CashuWallet, getDecodedToken, getTokenMetadata } =
-        await getCashuLib();
-      const det = getCashuDeterministicSeedFromStorage();
+      const { getDecodedToken, getTokenMetadata } = await getCashuLib();
 
       for (const row of cashuTokensAll) {
         if (row?.isDeleted) continue;
@@ -757,22 +794,19 @@ export const useCashuTokenChecks = ({
         group.tokens.push({ id, proofs: [], tokenText });
       }
 
-      if (groups.size === 0) return { checked: 0, claimed: 0 };
+      if (groups.size === 0) return { checked: 0, claimed: [] };
 
       checkIssuedInFlightRef.current = true;
       let checkedCount = 0;
-      let claimedCount = 0;
+      const claimed: Array<{ id: CashuTokenId; amount: number }> = [];
 
       try {
         for (const group of groups.values()) {
-          let wallet: Awaited<ReturnType<typeof createLoadedCashuWallet>>;
+          let wallet: LoadedCashuWallet;
           try {
-            wallet = await createLoadedCashuWallet({
-              CashuMint,
-              CashuWallet,
+            wallet = await loadIssuedClaimWallet({
               mintUrl: group.mintUrl,
               unit: group.unit,
-              ...(det ? { bip39seed: det.bip39seed } : {}),
             });
           } catch {
             // Mint unreachable — leave the group untouched, the user can
@@ -835,19 +869,27 @@ export const useCashuTokenChecks = ({
 
           for (const id of partition.fullySpentIds) {
             if (!id) continue;
+            const sourceRow = cashuTokensAll.find(
+              (entry) => String(entry?.id ?? "") === String(id),
+            );
+            const amountRaw = Number(sourceRow?.amount ?? 0);
+            const amount =
+              Number.isFinite(amountRaw) && amountRaw > 0
+                ? Math.trunc(amountRaw)
+                : 0;
             const result = updateCashuToken({
               id,
               isDeleted: Evolu.sqliteTrue,
             });
-            if (result.ok) claimedCount += 1;
+            if (result.ok) claimed.push({ id, amount });
           }
         }
       } finally {
         checkIssuedInFlightRef.current = false;
       }
 
-      return { checked: checkedCount, claimed: claimedCount };
-    }, [cashuTokensAll, updateCashuToken]);
+      return { checked: checkedCount, claimed };
+    }, [cashuTokensAll, loadIssuedClaimWallet, updateCashuToken]);
 
   // Same NUT-07 check as the bulk variant but scoped to a single issued
   // token row — used by the issued-token detail page to poll while the
@@ -869,17 +911,9 @@ export const useCashuTokenChecks = ({
       if (!mintUrl) return false;
       const unit = String(row.unit ?? "").trim() || "sat";
 
-      let wallet: Awaited<ReturnType<typeof createLoadedCashuWallet>>;
+      let wallet: LoadedCashuWallet;
       try {
-        const { CashuMint, CashuWallet } = await getCashuLib();
-        const det = getCashuDeterministicSeedFromStorage();
-        wallet = await createLoadedCashuWallet({
-          CashuMint,
-          CashuWallet,
-          mintUrl,
-          unit,
-          ...(det ? { bip39seed: det.bip39seed } : {}),
-        });
+        wallet = await loadIssuedClaimWallet({ mintUrl, unit });
       } catch {
         return false;
       }
@@ -931,7 +965,7 @@ export const useCashuTokenChecks = ({
       });
       return result.ok;
     },
-    [cashuTokensAll, updateCashuToken],
+    [cashuTokensAll, loadIssuedClaimWallet, updateCashuToken],
   );
 
   return {

--- a/apps/web-app/src/app/hooks/cashu/useCashuTokenChecks.ts
+++ b/apps/web-app/src/app/hooks/cashu/useCashuTokenChecks.ts
@@ -28,6 +28,7 @@ import {
   CASHU_TOKEN_STATE_PENDING,
   isCashuTokenAcceptedState,
   isCashuTokenEmittedState,
+  isCashuTokenIssuedState,
   normalizeCashuTokenState,
 } from "../../lib/cashuTokenState";
 import type { CashuTokenRowLike } from "../../types/appTypes";
@@ -693,9 +694,255 @@ export const useCashuTokenChecks = ({
     ],
   );
 
+  // Detect when a recipient has melted/swapped tokens we emitted (issue #86).
+  // wallet.checkProofsStates is the passive NUT-07 query — it does not
+  // consume proofs, so calling it on issued tokens is safe ("without
+  // ruining it"). Groups tokens by mint+unit so we only loadMint once per
+  // mint and batch one /v1/checkstate per group.
+  const checkIssuedCashuTokensAndDeleteClaimed =
+    React.useCallback(async (): Promise<{
+      checked: number;
+      claimed: number;
+    }> => {
+      if (cashuBulkCheckIsBusy) return { checked: 0, claimed: 0 };
+      if (cashuIsBusy) return { checked: 0, claimed: 0 };
+
+      // Group issued tokens by source mint+unit so each group needs only
+      // one wallet load + one /v1/checkstate round-trip.
+      const groups = new Map<
+        string,
+        {
+          mintUrl: string;
+          unit: string;
+          tokens: Array<{
+            id: CashuTokenId;
+            proofs: Proof[];
+            tokenText: string;
+          }>;
+        }
+      >();
+
+      const { CashuMint, CashuWallet, getDecodedToken, getTokenMetadata } =
+        await getCashuLib();
+      const det = getCashuDeterministicSeedFromStorage();
+
+      for (const row of cashuTokensAll) {
+        if (row?.isDeleted) continue;
+        if (!isCashuTokenIssuedState(row?.state)) continue;
+
+        const id = row?.id as CashuTokenId | undefined;
+        if (!id) continue;
+
+        const tokenText = String(row.token ?? row.rawToken ?? "").trim();
+        if (!tokenText) continue;
+
+        const parsed = parseCashuToken(tokenText);
+        const mintRaw = String(row.mint ?? parsed?.mint ?? "").trim();
+        const mintUrl = mintRaw ? normalizeMintUrl(mintRaw) : "";
+        if (!mintUrl) continue;
+        const unit = String(row.unit ?? "").trim() || "sat";
+
+        const groupKey = `${mintUrl}|${unit}`;
+        let group = groups.get(groupKey);
+        if (!group) {
+          group = { mintUrl, unit, tokens: [] };
+          groups.set(groupKey, group);
+        }
+        group.tokens.push({ id, proofs: [], tokenText });
+      }
+
+      if (groups.size === 0) return { checked: 0, claimed: 0 };
+
+      setCashuBulkCheckIsBusy(true);
+      setCashuIsBusy(true);
+
+      let checkedCount = 0;
+      let claimedCount = 0;
+
+      try {
+        for (const group of groups.values()) {
+          let wallet: Awaited<ReturnType<typeof createLoadedCashuWallet>>;
+          try {
+            wallet = await createLoadedCashuWallet({
+              CashuMint,
+              CashuWallet,
+              mintUrl: group.mintUrl,
+              unit: group.unit,
+              ...(det ? { bip39seed: det.bip39seed } : {}),
+            });
+          } catch {
+            // Mint unreachable — leave the group untouched, the user can
+            // re-run later when the mint comes back.
+            continue;
+          }
+
+          // Decode proofs against the loaded keysets. Tokens that fail to
+          // decode (corrupt / wrong mint) are skipped, not deleted — we
+          // don't have signal here to know whether they were claimed.
+          const decodedTokens: Array<{ id: CashuTokenId; proofs: Proof[] }> =
+            [];
+          for (const entry of group.tokens) {
+            try {
+              const decoded = decodeCashuTokenForMint({
+                tokenText: entry.tokenText,
+                mintUrl: group.mintUrl,
+                keysets: wallet.keysets,
+                getDecodedToken,
+                getTokenMetadata,
+              });
+              const proofs: Proof[] = [];
+              for (const p of decoded.proofs ?? []) {
+                proofs.push({
+                  amount: Number(p.amount ?? 0),
+                  secret: p.secret,
+                  C: p.C,
+                  id: p.id,
+                });
+              }
+              if (proofs.length === 0) continue;
+              decodedTokens.push({ id: entry.id, proofs });
+            } catch {
+              // skip
+            }
+          }
+
+          if (decodedTokens.length === 0) continue;
+
+          let states: ProofState[] = [];
+          try {
+            const flatProofs = decodedTokens.flatMap((entry) => entry.proofs);
+            const response = await wallet.checkProofsStates(flatProofs);
+            states = Array.isArray(response) ? response : [];
+          } catch {
+            // Mint state check failed — skip the group; next manual run
+            // gets another chance.
+            continue;
+          }
+
+          const partition = partitionCashuProofGroupsByState(
+            decodedTokens.map((entry) => ({
+              id: entry.id,
+              proofs: entry.proofs,
+            })),
+            states,
+          );
+
+          checkedCount += decodedTokens.length;
+
+          for (const id of partition.fullySpentIds) {
+            if (!id) continue;
+            const result = updateCashuToken({
+              id,
+              isDeleted: Evolu.sqliteTrue,
+            });
+            if (result.ok) claimedCount += 1;
+          }
+        }
+      } finally {
+        setCashuIsBusy(false);
+        setCashuBulkCheckIsBusy(false);
+      }
+
+      return { checked: checkedCount, claimed: claimedCount };
+    }, [
+      cashuBulkCheckIsBusy,
+      cashuIsBusy,
+      cashuTokensAll,
+      setCashuBulkCheckIsBusy,
+      setCashuIsBusy,
+      updateCashuToken,
+    ]);
+
+  // Same NUT-07 check as the bulk variant but scoped to a single issued
+  // token row — used by the issued-token detail page to poll while the
+  // user is staring at the QR. Returns true iff the row was deleted.
+  const checkSingleIssuedCashuTokenIsClaimed = React.useCallback(
+    async (id: CashuTokenId): Promise<boolean> => {
+      const row = cashuTokensAll.find(
+        (entry) => String(entry?.id ?? "") === String(id) && !entry?.isDeleted,
+      );
+      if (!row) return false;
+      if (!isCashuTokenIssuedState(row?.state)) return false;
+
+      const tokenText = String(row.token ?? row.rawToken ?? "").trim();
+      if (!tokenText) return false;
+
+      const parsed = parseCashuToken(tokenText);
+      const mintRaw = String(row.mint ?? parsed?.mint ?? "").trim();
+      const mintUrl = mintRaw ? normalizeMintUrl(mintRaw) : "";
+      if (!mintUrl) return false;
+      const unit = String(row.unit ?? "").trim() || "sat";
+
+      let wallet: Awaited<ReturnType<typeof createLoadedCashuWallet>>;
+      try {
+        const { CashuMint, CashuWallet } = await getCashuLib();
+        const det = getCashuDeterministicSeedFromStorage();
+        wallet = await createLoadedCashuWallet({
+          CashuMint,
+          CashuWallet,
+          mintUrl,
+          unit,
+          ...(det ? { bip39seed: det.bip39seed } : {}),
+        });
+      } catch {
+        return false;
+      }
+
+      const proofs: Proof[] = [];
+      try {
+        const { getDecodedToken, getTokenMetadata } = await getCashuLib();
+        const decoded = decodeCashuTokenForMint({
+          tokenText,
+          mintUrl,
+          keysets: wallet.keysets,
+          getDecodedToken,
+          getTokenMetadata,
+        });
+        for (const p of decoded.proofs ?? []) {
+          proofs.push({
+            amount: Number(p.amount ?? 0),
+            secret: p.secret,
+            C: p.C,
+            id: p.id,
+          });
+        }
+      } catch {
+        return false;
+      }
+
+      if (proofs.length === 0) return false;
+
+      let states: ProofState[] = [];
+      try {
+        const response = await wallet.checkProofsStates(proofs);
+        states = Array.isArray(response) ? response : [];
+      } catch {
+        return false;
+      }
+
+      const partition = partitionCashuProofGroupsByState(
+        [{ id, proofs }],
+        states,
+      );
+      const fullySpent = partition.fullySpentIds.some(
+        (entryId) => entryId !== null && String(entryId) === String(id),
+      );
+      if (!fullySpent) return false;
+
+      const result = updateCashuToken({
+        id,
+        isDeleted: Evolu.sqliteTrue,
+      });
+      return result.ok;
+    },
+    [cashuTokensAll, updateCashuToken],
+  );
+
   return {
     checkAllCashuTokensAndDeleteInvalid,
     checkAndRefreshCashuToken,
+    checkIssuedCashuTokensAndDeleteClaimed,
+    checkSingleIssuedCashuTokenIsClaimed,
     requestDeleteCashuToken,
   };
 };

--- a/apps/web-app/src/app/hooks/cashu/useRestoreMissingTokens.ts
+++ b/apps/web-app/src/app/hooks/cashu/useRestoreMissingTokens.ts
@@ -276,13 +276,11 @@ export const useRestoreMissingTokens = ({
             let wallet: Awaited<ReturnType<typeof createLoadedCashuWallet>>;
 
             try {
-              wallet = await createLoadedCashuWallet({
-                CashuMint,
-                CashuWallet,
-                mintUrl,
-                unit,
-                bip39seed: det.bip39seed,
-              });
+              // Reuse the loadMint() result if we've already touched this
+              // mint+unit earlier in the same restore pass — getWalletForMintUnit
+              // memoises by `${mintUrl}|${unit}` so we don't repay
+              // info+keysets+keys per nested loop iteration.
+              wallet = await getWalletForMintUnit(mintUrl, unit);
             } catch {
               // skip unreachable mints
               continue;

--- a/apps/web-app/src/app/routes/props/buildMoneyRouteProps.ts
+++ b/apps/web-app/src/app/routes/props/buildMoneyRouteProps.ts
@@ -30,6 +30,9 @@ interface BuildMoneyRoutePropsParams {
   checkSingleIssuedCashuTokenIsClaimed: ReturnType<
     MoneyRoutesProps["cashuTokenProps"]
   >["checkSingleIssuedCashuTokenIsClaimed"];
+  showPaidOverlay: ReturnType<
+    MoneyRoutesProps["cashuTokenProps"]
+  >["showPaidOverlay"];
   copyText: ReturnType<MoneyRoutesProps["cashuTokenProps"]>["copyText"];
   currentNpub: MoneyRoutesProps["topupProps"]["currentNpub"];
   displayUnit: MoneyRoutesProps["lnAddressPayProps"]["displayUnit"];
@@ -106,6 +109,7 @@ export const buildMoneyRouteProps = ({
   checkAndRefreshCashuToken,
   checkIssuedCashuTokensAndDeleteClaimed,
   checkSingleIssuedCashuTokenIsClaimed,
+  showPaidOverlay,
   copyText,
   currentNpub,
   displayUnit,
@@ -194,6 +198,7 @@ export const buildMoneyRouteProps = ({
         pendingCashuDeleteId,
         checkAndRefreshCashuToken,
         checkSingleIssuedCashuTokenIsClaimed,
+        showPaidOverlay,
         copyText,
         reserveCashuToken,
         requestDeleteCashuToken,

--- a/apps/web-app/src/app/routes/props/buildMoneyRouteProps.ts
+++ b/apps/web-app/src/app/routes/props/buildMoneyRouteProps.ts
@@ -26,6 +26,10 @@ interface BuildMoneyRoutePropsParams {
   checkAndRefreshCashuToken: ReturnType<
     MoneyRoutesProps["cashuTokenProps"]
   >["checkAndRefreshCashuToken"];
+  checkIssuedCashuTokensAndDeleteClaimed: MoneyRoutesProps["cashuTokensProps"]["checkIssuedCashuTokensAndDeleteClaimed"];
+  checkSingleIssuedCashuTokenIsClaimed: ReturnType<
+    MoneyRoutesProps["cashuTokenProps"]
+  >["checkSingleIssuedCashuTokenIsClaimed"];
   copyText: ReturnType<MoneyRoutesProps["cashuTokenProps"]>["copyText"];
   currentNpub: MoneyRoutesProps["topupProps"]["currentNpub"];
   displayUnit: MoneyRoutesProps["lnAddressPayProps"]["displayUnit"];
@@ -100,6 +104,8 @@ export const buildMoneyRouteProps = ({
   cashuOwnTokens,
   checkAllCashuTokensAndDeleteInvalid,
   checkAndRefreshCashuToken,
+  checkIssuedCashuTokensAndDeleteClaimed,
+  checkSingleIssuedCashuTokenIsClaimed,
   copyText,
   currentNpub,
   displayUnit,
@@ -167,6 +173,7 @@ export const buildMoneyRouteProps = ({
       cashuMeltToMainMintButtonLabel,
       cashuOwnTokens,
       checkAllCashuTokensAndDeleteInvalid,
+      checkIssuedCashuTokensAndDeleteClaimed,
       getMintIconUrl,
       meltLargestForeignMintToMainMint,
       restoreMissingTokens,
@@ -186,6 +193,7 @@ export const buildMoneyRouteProps = ({
         cashuIsBusy,
         pendingCashuDeleteId,
         checkAndRefreshCashuToken,
+        checkSingleIssuedCashuTokenIsClaimed,
         copyText,
         reserveCashuToken,
         requestDeleteCashuToken,

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -3772,14 +3772,26 @@ export const useAppShellComposition = () => {
   // bulkCheckIsBusy is true, so concurrent send/melt operations aren't
   // disturbed. Detection deletes the row, so the issued list cleans up
   // even when the user isn't sitting on #wallet/tokens.
+  //
+  // The helper's callback identity changes every time cashuTokensAll
+  // updates (Evolu emits frequently). Stashing it in a ref keeps the
+  // 60s interval from being torn down + restarted on every churn — the
+  // earlier inline-deps version was firing the check roughly every
+  // second under load.
   const hasAnyIssuedTokensForBackgroundCheck = cashuIssuedTokens.length > 0;
+  const checkIssuedCashuTokensRef = React.useRef(
+    checkIssuedCashuTokensAndDeleteClaimed,
+  );
+  React.useEffect(() => {
+    checkIssuedCashuTokensRef.current = checkIssuedCashuTokensAndDeleteClaimed;
+  }, [checkIssuedCashuTokensAndDeleteClaimed]);
   React.useEffect(() => {
     if (!hasAnyIssuedTokensForBackgroundCheck) return;
     let cancelled = false;
     const tick = async () => {
       if (cancelled) return;
       try {
-        await checkIssuedCashuTokensAndDeleteClaimed();
+        await checkIssuedCashuTokensRef.current();
       } catch {
         // ignore — the helper already swallows mint-side errors.
       }
@@ -3792,10 +3804,7 @@ export const useAppShellComposition = () => {
       cancelled = true;
       window.clearInterval(intervalId);
     };
-  }, [
-    checkIssuedCashuTokensAndDeleteClaimed,
-    hasAnyIssuedTokensForBackgroundCheck,
-  ]);
+  }, [hasAnyIssuedTokensForBackgroundCheck]);
 
   const copyText = React.useCallback(
     async (value: string) => {

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -3785,13 +3785,43 @@ export const useAppShellComposition = () => {
   React.useEffect(() => {
     checkIssuedCashuTokensRef.current = checkIssuedCashuTokensAndDeleteClaimed;
   }, [checkIssuedCashuTokensAndDeleteClaimed]);
+  const formatDisplayedAmountTextRef = React.useRef(formatDisplayedAmountText);
+  React.useEffect(() => {
+    formatDisplayedAmountTextRef.current = formatDisplayedAmountText;
+  }, [formatDisplayedAmountText]);
+  const pushToastRef = React.useRef(pushToast);
+  React.useEffect(() => {
+    pushToastRef.current = pushToast;
+  }, [pushToast]);
+  const claimToastTRef = React.useRef(t);
+  React.useEffect(() => {
+    claimToastTRef.current = t;
+  }, [t]);
   React.useEffect(() => {
     if (!hasAnyIssuedTokensForBackgroundCheck) return;
     let cancelled = false;
     const tick = async () => {
       if (cancelled) return;
       try {
-        await checkIssuedCashuTokensRef.current();
+        const outcome = await checkIssuedCashuTokensRef.current();
+        if (cancelled) return;
+        if (outcome.claimed.length === 0) return;
+        // Background detection — surface a toast so the user knows the
+        // issued token was redeemed even when they aren't on the QR
+        // screen (the CashuTokenPage poll handles the in-page UX with a
+        // checkmark overlay).
+        const formatter = formatDisplayedAmountTextRef.current;
+        const tt = claimToastTRef.current;
+        for (const entry of outcome.claimed) {
+          const message =
+            entry.amount > 0
+              ? tt("cashuTokenClaimedWithAmount").replace(
+                  "{amount}",
+                  formatter(entry.amount),
+                )
+              : tt("cashuTokenClaimed");
+          pushToastRef.current(message);
+        }
       } catch {
         // ignore — the helper already swallows mint-side errors.
       }
@@ -6145,6 +6175,7 @@ export const useAppShellComposition = () => {
       checkAndRefreshCashuToken,
       checkIssuedCashuTokensAndDeleteClaimed,
       checkSingleIssuedCashuTokenIsClaimed,
+      showPaidOverlay,
       copyText,
       currentNpub,
       displayUnit,

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -3747,6 +3747,8 @@ export const useAppShellComposition = () => {
   const {
     checkAllCashuTokensAndDeleteInvalid,
     checkAndRefreshCashuToken,
+    checkIssuedCashuTokensAndDeleteClaimed,
+    checkSingleIssuedCashuTokenIsClaimed,
     requestDeleteCashuToken,
   } = useCashuTokenChecks({
     appOwnerId: cashuOwnerId,
@@ -3762,6 +3764,38 @@ export const useAppShellComposition = () => {
     t,
     update,
   });
+
+  // Background check for issued-token claims (issue #86). Runs once on
+  // mount and every 60s thereafter while we have any issued tokens —
+  // wallet.checkProofsStates is the passive NUT-07 query that doesn't
+  // consume proofs. The helper itself skips when cashuIsBusy /
+  // bulkCheckIsBusy is true, so concurrent send/melt operations aren't
+  // disturbed. Detection deletes the row, so the issued list cleans up
+  // even when the user isn't sitting on #wallet/tokens.
+  const hasAnyIssuedTokensForBackgroundCheck = cashuIssuedTokens.length > 0;
+  React.useEffect(() => {
+    if (!hasAnyIssuedTokensForBackgroundCheck) return;
+    let cancelled = false;
+    const tick = async () => {
+      if (cancelled) return;
+      try {
+        await checkIssuedCashuTokensAndDeleteClaimed();
+      } catch {
+        // ignore — the helper already swallows mint-side errors.
+      }
+    };
+    void tick();
+    const intervalId = window.setInterval(() => {
+      void tick();
+    }, 60_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [
+    checkIssuedCashuTokensAndDeleteClaimed,
+    hasAnyIssuedTokensForBackgroundCheck,
+  ]);
 
   const copyText = React.useCallback(
     async (value: string) => {
@@ -6100,6 +6134,8 @@ export const useAppShellComposition = () => {
       cashuOwnTokens,
       checkAllCashuTokensAndDeleteInvalid,
       checkAndRefreshCashuToken,
+      checkIssuedCashuTokensAndDeleteClaimed,
+      checkSingleIssuedCashuTokenIsClaimed,
       copyText,
       currentNpub,
       displayUnit,

--- a/apps/web-app/src/i18n/cs.ts
+++ b/apps/web-app/src/i18n/cs.ts
@@ -532,6 +532,7 @@ export const cs = {
   cashuAcceptFailed: "Nepodařilo se přijmout token",
   cashuCheckToken: "Zkontrolovat token",
   cashuCheckAllTokens: "Zkontrolovat vše",
+  cashuCheckIssuedTokens: "Zkontrolovat využité",
   cashuChecking: "Kontroluji token…",
   cashuCheckOk: "Token je v pořádku.",
   pwaUpdateAvailable: "Nová verze Linky je k dispozici",

--- a/apps/web-app/src/i18n/cs.ts
+++ b/apps/web-app/src/i18n/cs.ts
@@ -645,6 +645,8 @@ export const cs = {
 
   // Locale-specific strings
   paid: "Zaplaceno",
+  cashuTokenClaimed: "Token byl využit",
+  cashuTokenClaimedWithAmount: "Tvůj token za {amount} byl využit",
   conversations: "Konverzace",
   otherContacts: "Ostatní kontakty",
   today: "Dnes",

--- a/apps/web-app/src/i18n/en.ts
+++ b/apps/web-app/src/i18n/en.ts
@@ -525,6 +525,7 @@ export const en = {
   cashuAcceptFailed: "Failed to accept token",
   cashuCheckToken: "Check token",
   cashuCheckAllTokens: "Check all",
+  cashuCheckIssuedTokens: "Check claimed",
   cashuChecking: "Checking token…",
   cashuCheckOk: "Token is OK.",
   pwaUpdateAvailable: "A new version of Linky is available",

--- a/apps/web-app/src/i18n/en.ts
+++ b/apps/web-app/src/i18n/en.ts
@@ -638,6 +638,8 @@ export const en = {
 
   // Locale-specific strings
   paid: "Paid",
+  cashuTokenClaimed: "Token claimed",
+  cashuTokenClaimedWithAmount: "Your token of {amount} has been claimed",
   conversations: "Conversations",
   otherContacts: "Other contacts",
   today: "Today",

--- a/apps/web-app/src/pages/CashuTokenPage.tsx
+++ b/apps/web-app/src/pages/CashuTokenPage.tsx
@@ -35,6 +35,7 @@ interface CashuTokenPageProps {
   returnCashuTokenToWallet: (id: CashuTokenId) => Promise<void>;
   routeId: CashuTokenId;
   shareTokenText: (id: CashuTokenId, text: string) => Promise<void>;
+  showPaidOverlay: (title?: string) => void;
   startSendCashuTokenToContact: (id: CashuTokenId) => Promise<void>;
   t: (key: string) => string;
   writeToNfc: (id: CashuTokenId, tokenText: string) => Promise<void>;
@@ -54,6 +55,7 @@ export const CashuTokenPage: FC<CashuTokenPageProps> = ({
   returnCashuTokenToWallet,
   routeId,
   shareTokenText,
+  showPaidOverlay,
   startSendCashuTokenToContact,
   t,
   writeToNfc,
@@ -169,6 +171,7 @@ export const CashuTokenPage: FC<CashuTokenPageProps> = ({
       try {
         const claimed = await checkSingleIssuedRef.current(routeId);
         if (claimed && !cancelled) {
+          showPaidOverlay(t("cashuTokenClaimed"));
           navigateTo({ route: "cashuTokens" });
         }
       } finally {
@@ -183,7 +186,7 @@ export const CashuTokenPage: FC<CashuTokenPageProps> = ({
       cancelled = true;
       window.clearInterval(intervalId);
     };
-  }, [isIssued, navigateTo, routeId]);
+  }, [isIssued, navigateTo, routeId, showPaidOverlay, t]);
 
   // If the row vanished after we had loaded it once (claim detector,
   // manual delete, etc.), bounce back to the tokens list instead of

--- a/apps/web-app/src/pages/CashuTokenPage.tsx
+++ b/apps/web-app/src/pages/CashuTokenPage.tsx
@@ -185,12 +185,19 @@ export const CashuTokenPage: FC<CashuTokenPageProps> = ({
     };
   }, [isIssued, navigateTo, routeId]);
 
-  // If the row vanished (the issued-token claim detector or any other
-  // path soft-deleted it while we were here), bounce back to the tokens
-  // list instead of rendering the generic error panel.
+  // If the row vanished after we had loaded it once (claim detector,
+  // manual delete, etc.), bounce back to the tokens list instead of
+  // rendering the generic error panel. Critical: do NOT navigate when
+  // the row is undefined on the FIRST render — cashuTokensAll is
+  // hydrated asynchronously from Evolu and is briefly empty on initial
+  // mount, which would otherwise kick the user out before the QR has
+  // a chance to render.
   const rowMissing = !row || !tokenMeta;
+  const hadRowRef = React.useRef(false);
+  if (!rowMissing) hadRowRef.current = true;
   React.useEffect(() => {
     if (!rowMissing) return;
+    if (!hadRowRef.current) return;
     navigateTo({ route: "cashuTokens" });
   }, [navigateTo, rowMissing]);
 

--- a/apps/web-app/src/pages/CashuTokenPage.tsx
+++ b/apps/web-app/src/pages/CashuTokenPage.tsx
@@ -26,6 +26,7 @@ interface CashuTokenPageProps {
   checkAndRefreshCashuToken: (
     id: CashuTokenId,
   ) => Promise<"ok" | "invalid" | "transient" | "skipped">;
+  checkSingleIssuedCashuTokenIsClaimed: (id: CashuTokenId) => Promise<boolean>;
   copyText: (text: string) => Promise<void>;
   pendingCashuDeleteId: CashuTokenId | null;
   reserveCashuToken: (id: CashuTokenId) => Promise<void>;
@@ -44,6 +45,7 @@ export const CashuTokenPage: FC<CashuTokenPageProps> = ({
   cashuIsBusy,
   cashuTokensAll,
   checkAndRefreshCashuToken,
+  checkSingleIssuedCashuTokenIsClaimed,
   copyText,
   pendingCashuDeleteId,
   reserveCashuToken,
@@ -135,6 +137,36 @@ export const CashuTokenPage: FC<CashuTokenPageProps> = ({
       cancelled = true;
     };
   }, [tokenText]);
+
+  // Poll the source mint while the user is staring at the QR of an issued
+  // token (issue #86): wallet.checkProofsStates is the passive NUT-07
+  // query, so it doesn't consume the proofs. Once all proofs flip to
+  // SPENT the helper soft-deletes the row, the page re-renders without
+  // it and the "Token not found" path triggers — at which point we no
+  // longer need to keep polling.
+  React.useEffect(() => {
+    if (!isIssued) return;
+
+    let cancelled = false;
+    let inFlight = false;
+    const tick = async () => {
+      if (cancelled || inFlight) return;
+      inFlight = true;
+      try {
+        await checkSingleIssuedCashuTokenIsClaimed(routeId);
+      } finally {
+        inFlight = false;
+      }
+    };
+    void tick();
+    const intervalId = window.setInterval(() => {
+      void tick();
+    }, 10_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [checkSingleIssuedCashuTokenIsClaimed, isIssued, routeId]);
 
   if (!row || !tokenMeta) {
     return (

--- a/apps/web-app/src/pages/CashuTokenPage.tsx
+++ b/apps/web-app/src/pages/CashuTokenPage.tsx
@@ -14,6 +14,7 @@ import { parseCashuToken } from "../cashu";
 import { NfcIcon } from "../components/NfcIcon";
 import { WalletBalance } from "../components/WalletBalance";
 import type { CashuTokenId } from "../evolu";
+import { useNavigation } from "../hooks/useRouting";
 import { buildCashuShareUrl } from "../utils/deepLinks";
 
 type CashuTokenPageRow = CashuTokenRowLike & { id: CashuTokenId };
@@ -58,6 +59,7 @@ export const CashuTokenPage: FC<CashuTokenPageProps> = ({
   writeToNfc,
 }) => {
   const { formatDisplayedAmountText } = useAppShellCore();
+  const navigateTo = useNavigation();
   const [tokenQr, setTokenQr] = React.useState<string | null>(null);
   const row = cashuTokensAll.find(
     (tkn) => tkn.id === routeId && !tkn.isDeleted,
@@ -141,9 +143,21 @@ export const CashuTokenPage: FC<CashuTokenPageProps> = ({
   // Poll the source mint while the user is staring at the QR of an issued
   // token (issue #86): wallet.checkProofsStates is the passive NUT-07
   // query, so it doesn't consume the proofs. Once all proofs flip to
-  // SPENT the helper soft-deletes the row, the page re-renders without
-  // it and the "Token not found" path triggers — at which point we no
-  // longer need to keep polling.
+  // SPENT the helper soft-deletes the row and we navigate back to the
+  // tokens list — staying on the now-orphan detail page would just
+  // render the generic error panel.
+  //
+  // The helper's identity changes whenever cashuTokensAll updates, so
+  // we stash the latest reference in a ref to keep the 10s interval
+  // from being torn down + restarted on every churn. Without this the
+  // tick was effectively firing every couple of seconds under load.
+  const checkSingleIssuedRef = React.useRef(
+    checkSingleIssuedCashuTokenIsClaimed,
+  );
+  React.useEffect(() => {
+    checkSingleIssuedRef.current = checkSingleIssuedCashuTokenIsClaimed;
+  }, [checkSingleIssuedCashuTokenIsClaimed]);
+
   React.useEffect(() => {
     if (!isIssued) return;
 
@@ -153,7 +167,10 @@ export const CashuTokenPage: FC<CashuTokenPageProps> = ({
       if (cancelled || inFlight) return;
       inFlight = true;
       try {
-        await checkSingleIssuedCashuTokenIsClaimed(routeId);
+        const claimed = await checkSingleIssuedRef.current(routeId);
+        if (claimed && !cancelled) {
+          navigateTo({ route: "cashuTokens" });
+        }
       } finally {
         inFlight = false;
       }
@@ -166,14 +183,19 @@ export const CashuTokenPage: FC<CashuTokenPageProps> = ({
       cancelled = true;
       window.clearInterval(intervalId);
     };
-  }, [checkSingleIssuedCashuTokenIsClaimed, isIssued, routeId]);
+  }, [isIssued, navigateTo, routeId]);
 
-  if (!row || !tokenMeta) {
-    return (
-      <section className="panel">
-        <p className="muted">{t("errorPrefix")}</p>
-      </section>
-    );
+  // If the row vanished (the issued-token claim detector or any other
+  // path soft-deleted it while we were here), bounce back to the tokens
+  // list instead of rendering the generic error panel.
+  const rowMissing = !row || !tokenMeta;
+  React.useEffect(() => {
+    if (!rowMissing) return;
+    navigateTo({ route: "cashuTokens" });
+  }, [navigateTo, rowMissing]);
+
+  if (rowMissing) {
+    return null;
   }
 
   const safeRow = row;

--- a/apps/web-app/src/pages/CashuTokensPage.tsx
+++ b/apps/web-app/src/pages/CashuTokensPage.tsx
@@ -21,7 +21,7 @@ interface CashuTokensPageProps {
   checkAllCashuTokensAndDeleteInvalid: () => Promise<void>;
   checkIssuedCashuTokensAndDeleteClaimed: () => Promise<{
     checked: number;
-    claimed: number;
+    claimed: ReadonlyArray<{ id: CashuTokenId; amount: number }>;
   }>;
   getMintIconUrl: (mint: MintUrlInput) => {
     origin: string | null;

--- a/apps/web-app/src/pages/CashuTokensPage.tsx
+++ b/apps/web-app/src/pages/CashuTokensPage.tsx
@@ -1,4 +1,5 @@
 import type { Dispatch, FC, SetStateAction } from "react";
+import { useEffect, useRef } from "react";
 import { useAppShellCore } from "../app/context/AppShellContexts";
 import type { CashuTokenRowLike, MintUrlInput } from "../app/types/appTypes";
 import { CashuTokenPill } from "../components/CashuTokenPill";
@@ -18,6 +19,10 @@ interface CashuTokensPageProps {
   cashuOwnTokens: readonly CashuTokenListItem[];
   cashuIssuedTokens: readonly CashuTokenListItem[];
   checkAllCashuTokensAndDeleteInvalid: () => Promise<void>;
+  checkIssuedCashuTokensAndDeleteClaimed: () => Promise<{
+    checked: number;
+    claimed: number;
+  }>;
   getMintIconUrl: (mint: MintUrlInput) => {
     origin: string | null;
     url: string | null;
@@ -40,6 +45,7 @@ export const CashuTokensPage: FC<CashuTokensPageProps> = ({
   cashuMeltToMainMintButtonLabel,
   cashuOwnTokens,
   checkAllCashuTokensAndDeleteInvalid,
+  checkIssuedCashuTokensAndDeleteClaimed,
   getMintIconUrl,
   meltLargestForeignMintToMainMint,
   restoreMissingTokens,
@@ -53,6 +59,15 @@ export const CashuTokensPage: FC<CashuTokensPageProps> = ({
     const amount = Number(token.amount ?? 0);
     return sum + (Number.isFinite(amount) ? amount : 0);
   }, 0);
+
+  const hasIssuedTokens = cashuIssuedTokens.length > 0;
+  const autoCheckedRef = useRef(false);
+  useEffect(() => {
+    if (!hasIssuedTokens) return;
+    if (autoCheckedRef.current) return;
+    autoCheckedRef.current = true;
+    void checkIssuedCashuTokensAndDeleteClaimed();
+  }, [checkIssuedCashuTokensAndDeleteClaimed, hasIssuedTokens]);
 
   const renderTokenList = (
     tokens: readonly CashuTokenListItem[],
@@ -146,6 +161,14 @@ export const CashuTokensPage: FC<CashuTokensPageProps> = ({
             <span>
               {t("cashuIssued")} · {formatDisplayedAmountText(issuedBalance)}
             </span>
+            <button
+              type="button"
+              className="btn-small secondary"
+              onClick={() => void checkIssuedCashuTokensAndDeleteClaimed()}
+              disabled={cashuIsBusy || cashuBulkCheckIsBusy || !hasIssuedTokens}
+            >
+              {t("cashuCheckIssuedTokens")}
+            </button>
           </div>
           {renderTokenList(cashuIssuedTokens, t("cashuIssuedEmpty"))}
           <div className="settings-row" style={{ marginTop: 12 }}>

--- a/apps/web-app/src/pages/CashuTokensPage.tsx
+++ b/apps/web-app/src/pages/CashuTokensPage.tsx
@@ -165,7 +165,7 @@ export const CashuTokensPage: FC<CashuTokensPageProps> = ({
               type="button"
               className="btn-small secondary"
               onClick={() => void checkIssuedCashuTokensAndDeleteClaimed()}
-              disabled={cashuIsBusy || cashuBulkCheckIsBusy || !hasIssuedTokens}
+              disabled={!hasIssuedTokens}
             >
               {t("cashuCheckIssuedTokens")}
             </button>


### PR DESCRIPTION
Closes #86.

  ## Summary

  Issued tokens used to stay in the `emitované` list forever even after the recipient melted/swapped them — nothing in the app polled the mint. Adds NUT-07
  (`POST /v1/checkstate`) polling at three points so the row deletes itself once all its proofs flip to `SPENT`. `wallet.checkProofsStates` is the passive read —
   it does **not** consume proofs, so polling on the issuer side is safe ("without ruining it" per the issue).
  
  ### Where the check fires

  1. **Background tick** in `useAppShellComposition` — every 60s while any issued tokens exist, regardless of which route the user is on. The `emitované` list
  cleans itself up even if the user never opens the wallet tab. On detection a toast surfaces with the claimed amount (`Your token of N has been claimed` / `Tvůj
   token za N byl využit`).
  2. **`#wallet/tokens`** — one-shot pass on mount when issued tokens are present, plus a manual **Check claimed** / **Zkontrolovat využité** button next to the
  issued header.
  3. **`#cashuToken/<id>` (issued detail)** — 10s poll while the user is on the QR screen. On detection the existing `showPaidOverlay` ✓ checkmark flashes
  (matching the rest of the app's payment feedback) and the page navigates back to the tokens list.

  ### Helpers
  
  Two NUT-07 helpers live in `useCashuTokenChecks`:

  - `checkIssuedCashuTokensAndDeleteClaimed()` — groups all issued tokens by `mint+unit`, batches **one** `POST /v1/checkstate` per group, soft-deletes any row
  whose proofs are all `SPENT`. Returns the claimed rows' amounts so the caller can compose a toast.
  - `checkSingleIssuedCashuTokenIsClaimed(id)` — the same logic scoped to a single row for the detail-page polling.

  ### UX guarantees

  - **UI stays usable while the check runs.** The helpers do **not** toggle `cashuIsBusy` / `cashuBulkCheckIsBusy` — Issue / Melt to mint / Restore tokens /
  Send-to-contact buttons stay clickable. A local in-flight ref serializes concurrent self-calls.
  - **No polling spam.** Both ticks stash the helper callbacks in refs so the 60s / 10s intervals don't get torn down on every Evolu emit (without this, mint
  logs showed bursts of mint round-trips every ~1.5s).
  - **No redundant `loadMint()`.** A hook-level `cashuWalletCacheRef` is shared by every check path in `useCashuTokenChecks` (bulk check-all, single-token check,
   issued-claim bulk + single, manual buttons + ticks). `info`+`keysets`+`keys` fire **once per `mint|unit` per session**; all subsequent reads reuse the wallet
  handle. Cache clears on hook unmount (logout / shell teardown).
  - **Same wallet cache pattern applied** to `useRestoreMissingTokens` — the inner per-unit loop was bypassing the local `walletByMintUnit` cache that the
  seed-secret discovery loop already had; it now routes through `getWalletForMintUnit` too.
  - **Detail page doesn't bounce on initial load.** A `hadRowRef` guard prevents the row-vanished auto-navigation from firing while `cashuTokensAll` is still
  hydrating from Evolu on initial mount, so the QR renders normally when the user opens an issued token.

  ## Test plan
  
  - [ ] `bun run check-code` is green.
  - [ ] Issue a Cashu token via `#wallet/token/emit`. Confirm the row appears in `emitované`. On a second device / wallet, claim the token (melt or swap). Within
   ~60s the row should disappear from the original wallet and a toast appears with the claimed amount.
  - [ ] Same flow but stay on the issued token's QR detail page. Within ~10s of the claim the ✓ checkmark flashes and the page navigates back to
  `#wallet/tokens`.
  - [ ] On `#wallet/tokens`, click **Check claimed** / **Zkontrolovat využité**: claimed tokens disappear immediately.
  - [ ] During an active check, click **Issue / Melt to mint / Restore tokens** — all buttons remain responsive (no busy lock).
  - [ ] Token whose source mint is offline: stays in the list, no error toast (transient skip), retry on next tick.
  - [ ] Multiple issued tokens across different mints: mint logs show one `info`+`keysets`+`keys` per `mint|unit` for the lifetime of the session; later checks
  only fire `POST /v1/checkstate`.
  - [ ] Tab focus / visibilitychange / online events do not double-trigger the per-tick wallet load (`cashuWalletCacheRef` hit).