### PR TITLE
feat(lnurl): LUD-06 / LUD-09 LNURL-pay support and melt fee probe

### DIFF
--- a/apps/web-app/src/App.css
+++ b/apps/web-app/src/App.css
@@ -2546,6 +2546,19 @@ button.danger {
   color: var(--color-text-muted);
 }
 
+.transaction-subtitle {
+  margin-top: 3px;
+  font-size: 13px;
+  color: var(--color-text-secondary, var(--color-text-primary));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  white-space: pre-line;
+  word-break: break-word;
+}
+
 .transaction-amount {
   flex: 0 0 auto;
   font-size: 14px;

--- a/apps/web-app/src/app/hooks/useLightningPaymentsDomain.ts
+++ b/apps/web-app/src/app/hooks/useLightningPaymentsDomain.ts
@@ -6,6 +6,7 @@ import {
   getLnurlPayDisplayText,
   inferLightningAddressFromLnurlTarget,
   isLightningAddress,
+  type LnurlPaySuccessAction,
 } from "../../lnurlPay";
 import { CONTACTS_ONBOARDING_HAS_PAID_STORAGE_KEY } from "../../utils/constants";
 import type { DisplayAmountParts } from "../../utils/displayAmounts";
@@ -497,12 +498,15 @@ export const useLightningPaymentsDomain = ({
 
           let attemptInvoice: string;
           let attemptInvoicePreview: LightningInvoicePreview | null = null;
+          let attemptSuccessAction: LnurlPaySuccessAction | null = null;
           try {
             setStatus(t("payFetchingInvoice"));
-            attemptInvoice = await fetchLnurlInvoiceForTarget(
+            const invoiceResult = await fetchLnurlInvoiceForTarget(
               paymentTarget,
               attemptedAmountSat,
             );
+            attemptInvoice = invoiceResult.pr;
+            attemptSuccessAction = invoiceResult.successAction;
             attemptInvoicePreview = getLightningInvoicePreview(attemptInvoice);
             lastAttemptInvoice = attemptInvoice;
             lastAttemptInvoicePreview = attemptInvoicePreview;
@@ -620,6 +624,19 @@ export const useLightningPaymentsDomain = ({
                 (result as { feePaid?: unknown }).feePaid ?? 0,
               );
 
+              const successActionMessage =
+                attemptSuccessAction?.tag === "message"
+                  ? attemptSuccessAction.message
+                  : null;
+              const successActionUrl =
+                attemptSuccessAction?.tag === "url"
+                  ? attemptSuccessAction.url
+                  : null;
+              const successActionUrlDescription =
+                attemptSuccessAction?.tag === "url"
+                  ? attemptSuccessAction.description
+                  : null;
+
               logPaymentEvent({
                 direction: "out",
                 status: "ok",
@@ -637,6 +654,17 @@ export const useLightningPaymentsDomain = ({
                     : {}),
                   ...(readLightningPreimage(result)
                     ? { lightningPreimage: readLightningPreimage(result) }
+                    : {}),
+                  ...(successActionMessage
+                    ? { lnurlSuccessMessage: successActionMessage }
+                    : {}),
+                  ...(successActionUrl
+                    ? { lnurlSuccessUrl: successActionUrl }
+                    : {}),
+                  ...(successActionUrlDescription
+                    ? {
+                        lnurlSuccessUrlDescription: successActionUrlDescription,
+                      }
                     : {}),
                   usedInputTokens: candidate.tokens,
                 },
@@ -664,6 +692,21 @@ export const useLightningPaymentsDomain = ({
                     String(knownContact?.name ?? "").trim() || displayTarget,
                   ),
               );
+
+              if (successActionMessage) {
+                setStatus(
+                  t("lnurlSuccessActionMessage").replace(
+                    "{message}",
+                    successActionMessage,
+                  ),
+                );
+              } else if (successActionUrl) {
+                setStatus(
+                  t("lnurlSuccessActionUrl")
+                    .replace("{description}", successActionUrlDescription ?? "")
+                    .replace("{url}", successActionUrl),
+                );
+              }
 
               safeLocalStorageSet(
                 CONTACTS_ONBOARDING_HAS_PAID_STORAGE_KEY,

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -5896,6 +5896,55 @@ export const useAppShellComposition = () => {
         finalError = getUnknownErrorMessage(error, "unknown");
       }
 
+      // Pre-flight fee discovery: ask source mint how much fee_reserve + input
+      // fee it will charge for a probe invoice of the full sourceBalance, then
+      // size the first target-mint invoice as
+      //   sourceAmount = sourceBalance - fee_reserve - input_fee
+      // so the first real melt attempt has the right headroom instead of
+      // burning the entire retry ladder hitting Insufficient.
+      if (sourceMeltContext) {
+        try {
+          const probe = await requestMintQuoteBolt11({
+            amountSat: sourceBalance,
+            mintUrl: targetMint,
+          });
+          const probeMeltQuote = await sourceMeltContext.wallet.createMeltQuote(
+            probe.invoice,
+          );
+          const probeFeeReserve = Number(probeMeltQuote.fee_reserve ?? 0) || 0;
+          const probeInputFee =
+            Number(
+              sourceMeltContext.wallet.getFeesForProofs(
+                sourceMeltContext.spendableProofs,
+              ) ?? 0,
+            ) || 0;
+          const sizedAmount = Math.max(
+            1,
+            sourceBalance - probeFeeReserve - probeInputFee,
+          );
+          if (
+            Number.isFinite(sizedAmount) &&
+            sizedAmount >= 1 &&
+            sizedAmount < sourceBalance
+          ) {
+            // Drop the no-fee-reserve attempts that we now know will fail and
+            // promote the discovered sized amount to the front of the queue.
+            const tail = queuedAmountAttempts.filter(
+              (candidate) => candidate < sizedAmount,
+            );
+            queuedAmountAttempts.length = 0;
+            queuedAmountAttempts.push(sizedAmount, ...tail);
+            seenAmountAttempts.clear();
+            for (const candidate of queuedAmountAttempts) {
+              seenAmountAttempts.add(candidate);
+            }
+          }
+        } catch {
+          // Probe failed (rate-limited mint, network error, etc.). Fall
+          // through to the original retry strategy starting from sourceBalance.
+        }
+      }
+
       let activeSourceRows: Array<{ id?: CashuTokenId | string | null }> =
         sourceRows;
       let activeSourceOwnerId = cashuOwnerId;

--- a/apps/web-app/src/i18n/cs.ts
+++ b/apps/web-app/src/i18n/cs.ts
@@ -261,6 +261,8 @@ export const cs = {
   transactionDetailLightningMemo: "Lightning memo",
   transactionDetailLightningInvoice: "Lightning invoice",
   transactionDetailLightningPreimage: "Lightning preimage",
+  transactionDetailLnurlSuccessMessage: "Zpráva od příjemce",
+  transactionDetailLnurlSuccessUrl: "Odkaz od příjemce",
 
   mints: "Minty",
 
@@ -634,6 +636,14 @@ export const cs = {
   lnurlWithdrawPending: "Výběr čeká na připsání do peněženky.",
   lnurlWithdrawFailed: "Výběr přes LNURLw selhal",
   lnurlWithdrawVariableAmount: "Linky vyzvedne maximální dostupnou částku.",
+  lnurlPayLoading: "Načítám platební údaje…",
+  lnurlPayLoadFailed: "Nepodařilo se načíst platební údaje",
+  lnurlPayRangeHint: "Zadej částku mezi {min} a {max} sat.",
+  lnurlPayFixedHint: "Příjemce požaduje přesně {amount} sat.",
+  lnurlPayAmountTooLow: "Částka je pod minimum {min} sat.",
+  lnurlPayAmountTooHigh: "Částka přesahuje maximum {max} sat.",
+  lnurlSuccessActionMessage: "Zpráva od příjemce: {message}",
+  lnurlSuccessActionUrl: "{description} {url}",
   payMissingLn: "Chybí lightning adresa.",
   payInvalidAmount: "Neplatná částka",
   payInsufficient: "Nemáte dostatek Cashu tokenů.",

--- a/apps/web-app/src/i18n/en.ts
+++ b/apps/web-app/src/i18n/en.ts
@@ -259,6 +259,8 @@ export const en = {
   transactionDetailLightningMemo: "Lightning memo",
   transactionDetailLightningInvoice: "Lightning invoice",
   transactionDetailLightningPreimage: "Lightning preimage",
+  transactionDetailLnurlSuccessMessage: "Message from recipient",
+  transactionDetailLnurlSuccessUrl: "Link from recipient",
 
   mints: "Mints",
 
@@ -627,6 +629,14 @@ export const en = {
   lnurlWithdrawFailed: "LNURLw withdrawal failed",
   lnurlWithdrawVariableAmount:
     "Linky will receive the maximum available amount.",
+  lnurlPayLoading: "Loading payment details…",
+  lnurlPayLoadFailed: "Couldn't load payment details",
+  lnurlPayRangeHint: "Enter amount between {min} and {max} sat.",
+  lnurlPayFixedHint: "Recipient requires exactly {amount} sat.",
+  lnurlPayAmountTooLow: "Amount is below the {min} sat minimum.",
+  lnurlPayAmountTooHigh: "Amount is above the {max} sat maximum.",
+  lnurlSuccessActionMessage: "Message from recipient: {message}",
+  lnurlSuccessActionUrl: "{description} {url}",
   payMissingLn: "Missing lightning address.",
   payInvalidAmount: "Invalid amount",
   payInsufficient: "Not enough Cashu tokens.",

--- a/apps/web-app/src/lnurlPay.ts
+++ b/apps/web-app/src/lnurlPay.ts
@@ -1,7 +1,12 @@
 import { bech32 } from "@scure/base";
+import { sha256 } from "@noble/hashes/sha2.js";
 import { isNativePlatform } from "./platform/runtime";
 import type { JsonRecord, JsonValue } from "./types/json";
 import { fetchJson } from "./utils/http";
+import {
+  getLightningInvoiceDescriptionHashHex,
+  parseBolt11AmountMsat,
+} from "./utils/lightningInvoice";
 import { asNonEmptyString } from "./utils/validation";
 
 const HOSTED_APP_ORIGIN = "https://app.linky.fit";
@@ -22,7 +27,28 @@ type LnurlInvoiceResponse = {
   pr?: string;
   reason?: string;
   status?: string;
+  successAction?: JsonValue;
 };
+
+export interface LnurlPaySuccessActionMessage {
+  message: string;
+  tag: "message";
+}
+
+export interface LnurlPaySuccessActionUrl {
+  description: string | null;
+  tag: "url";
+  url: string;
+}
+
+export type LnurlPaySuccessAction =
+  | LnurlPaySuccessActionMessage
+  | LnurlPaySuccessActionUrl;
+
+export interface LnurlPayInvoiceResult {
+  pr: string;
+  successAction: LnurlPaySuccessAction | null;
+}
 
 type LnurlWithdrawRequest = {
   callback?: string;
@@ -47,6 +73,18 @@ export interface LnurlWithdrawPreview {
   k1: string;
   maxAmountSat: number;
   minAmountSat: number;
+  target: string;
+}
+
+export interface LnurlPayPreview {
+  callback: string;
+  commentAllowed: number;
+  description: string | null;
+  maxSendableMsat: number;
+  maxSendableSat: number;
+  metadataRaw: string | null;
+  minSendableMsat: number;
+  minSendableSat: number;
   target: string;
 }
 
@@ -102,6 +140,25 @@ const isHttpUrl = (value: string): boolean => {
   }
 };
 
+// Some LNURL encoders ship URLs with empty path segments (e.g.
+// `https://lnbits.cz/lnurlp//AVH9zJ`). Most servers respond 404 to the empty
+// segment but answer the same content under the collapsed path. Mirror the
+// behavior of other LNURL wallets by collapsing consecutive slashes in the
+// path while leaving the `://` authority and the query/fragment untouched.
+const normalizeLnurlHttpUrl = (value: string): string => {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return value;
+    const collapsedPath = url.pathname.replace(/\/{2,}/g, "/");
+    if (collapsedPath !== url.pathname) {
+      url.pathname = collapsedPath;
+    }
+    return url.toString();
+  } catch {
+    return value;
+  }
+};
+
 const decodeLnurlBech32Url = (value: string): string | null => {
   const normalized = stripLightningPrefix(value);
   if (!/^lnurl1/i.test(normalized)) return null;
@@ -111,7 +168,8 @@ const decodeLnurlBech32Url = (value: string): string | null => {
     if (!decoded) return null;
     const bytes = Uint8Array.from(bech32.fromWords(decoded.words));
     const text = new TextDecoder().decode(bytes).trim();
-    return isHttpUrl(text) ? text : null;
+    if (!isHttpUrl(text)) return null;
+    return normalizeLnurlHttpUrl(text);
   } catch {
     return null;
   }
@@ -274,6 +332,44 @@ const isLnurlInvoiceResponse = (
   );
 };
 
+const parseLnurlPaySuccessAction = (
+  value: JsonValue | undefined,
+): LnurlPaySuccessAction | null => {
+  if (!isJsonRecord(value)) return null;
+  const tag = String(value.tag ?? "")
+    .trim()
+    .toLowerCase();
+
+  if (tag === "message") {
+    const message = asNonEmptyString(value.message);
+    if (!message) return null;
+    return { tag: "message", message };
+  }
+
+  if (tag === "url") {
+    const url = asNonEmptyString(value.url);
+    if (!url) return null;
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+        return null;
+      }
+    } catch {
+      return null;
+    }
+    return {
+      tag: "url",
+      url,
+      description: asNonEmptyString(value.description) ?? null,
+    };
+  }
+
+  // Other LUD-09 tags (e.g. "aes") are intentionally not surfaced here. The
+  // caller can fall back to a generic "Paid" message; we only render the
+  // tags we know how to display safely.
+  return null;
+};
+
 const isLnurlWithdrawRequest = (
   value: unknown,
 ): value is LnurlWithdrawRequest => {
@@ -311,10 +407,29 @@ const getLnurlpUrlFromLightningAddress = (lightningAddress: string): string => {
   return `https://${domain}/.well-known/lnurlp/${encodeURIComponent(user)}`;
 };
 
+const HOSTED_PROXY_LOCAL_HOSTS = new Set([
+  "app.linky.fit",
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+]);
+
 const getLnurlProxyUrl = (url: string): string => {
   const proxyPath = `/api/lnurlp?url=${encodeURIComponent(url)}`;
   if (isNativePlatform()) {
     return `${HOSTED_APP_ORIGIN}${proxyPath}`;
+  }
+  if (typeof window !== "undefined") {
+    const host = String(window.location?.hostname ?? "")
+      .trim()
+      .toLowerCase();
+    // Same-origin proxy only exists on app.linky.fit and the Vite dev server.
+    // Other hosts (linky.gorrdy.cz, staging mirrors, etc.) don't proxy
+    // /api/lnurlp themselves, so route the CORS bypass through the canonical
+    // hosted origin.
+    if (host && !HOSTED_PROXY_LOCAL_HOSTS.has(host)) {
+      return `${HOSTED_APP_ORIGIN}${proxyPath}`;
+    }
   }
   return proxyPath;
 };
@@ -328,11 +443,117 @@ const fetchLnurlJson = async (url: string): Promise<JsonValue> => {
   }
 };
 
+interface ParsedLnurlPayMetadata {
+  description: string | null;
+}
+
+const parseLnurlPayMetadata = (
+  metadata: string | null,
+): ParsedLnurlPayMetadata | null => {
+  if (!metadata) return null;
+  try {
+    const parsed: unknown = JSON.parse(metadata);
+    if (!Array.isArray(parsed)) return null;
+    let hasTextPlain = false;
+    let description: string | null = null;
+    for (const entry of parsed) {
+      if (!Array.isArray(entry) || entry.length < 2) continue;
+      const [mime, value] = entry;
+      if (typeof mime !== "string" || typeof value !== "string") continue;
+      if (mime.trim().toLowerCase() === "text/plain") {
+        hasTextPlain = true;
+        const trimmed = value.trim();
+        if (trimmed && description === null) description = trimmed;
+      }
+    }
+    return hasTextPlain ? { description } : null;
+  } catch {
+    return null;
+  }
+};
+
+const sha256HexFromString = (input: string): string => {
+  const bytes = sha256(new TextEncoder().encode(input));
+  let hex = "";
+  for (const byte of bytes) hex += byte.toString(16).padStart(2, "0");
+  return hex;
+};
+
+export const fetchLnurlPayPreview = async (
+  paymentTarget: string,
+): Promise<LnurlPayPreview> => {
+  const requestUrl = resolveLnurlPayRequestUrl(paymentTarget);
+  const payReqJson = await fetchLnurlJson(requestUrl);
+  if (!isLnurlPayRequest(payReqJson)) {
+    throw new Error("Invalid LNURL pay response");
+  }
+  const payReq = payReqJson;
+
+  const tag = String(payReq.tag ?? "").trim();
+  const looksLikePayRequest =
+    asNonEmptyString(payReq.callback) !== null &&
+    Number.isFinite(Number(payReq.minSendable ?? NaN)) &&
+    Number.isFinite(Number(payReq.maxSendable ?? NaN));
+
+  if (!looksLikePayRequest && !isKnownLnurlTag(tag, "payRequest")) {
+    throw new LnurlTagMismatchError(tag);
+  }
+
+  if (String(payReq.status ?? "").toUpperCase() === "ERROR") {
+    throw new Error(asNonEmptyString(payReq.reason) ?? "LNURL error");
+  }
+
+  const callback = asNonEmptyString(payReq.callback);
+  if (!callback) throw new Error("LNURL callback missing");
+
+  const minSendableMsat = Number(payReq.minSendable ?? NaN);
+  const maxSendableMsat = Number(payReq.maxSendable ?? NaN);
+  if (
+    !Number.isFinite(minSendableMsat) ||
+    !Number.isFinite(maxSendableMsat) ||
+    minSendableMsat <= 0 ||
+    maxSendableMsat <= 0 ||
+    maxSendableMsat < minSendableMsat
+  ) {
+    throw new Error("Invalid LNURL min/max");
+  }
+
+  const minSendableSat = Math.max(1, Math.ceil(minSendableMsat / 1000));
+  const maxSendableSat = Math.max(
+    minSendableSat,
+    Math.floor(maxSendableMsat / 1000),
+  );
+
+  const metadataRaw = asNonEmptyString(payReq.metadata);
+  const parsedMetadata = parseLnurlPayMetadata(metadataRaw);
+  if (!parsedMetadata) {
+    throw new Error("LNURL metadata missing text/plain entry");
+  }
+
+  const commentAllowedRaw = Number(payReq.commentAllowed ?? 0);
+  const commentAllowed =
+    Number.isFinite(commentAllowedRaw) && commentAllowedRaw > 0
+      ? Math.floor(commentAllowedRaw)
+      : 0;
+
+  return {
+    callback,
+    commentAllowed,
+    description: parsedMetadata.description,
+    maxSendableMsat,
+    maxSendableSat,
+    metadataRaw,
+    minSendableMsat,
+    minSendableSat,
+    target: getLnurlPayDisplayText(requestUrl),
+  };
+};
+
 export const fetchLnurlInvoiceForTarget = async (
   paymentTarget: string,
   amountSat: number,
   comment?: string,
-): Promise<string> => {
+): Promise<LnurlPayInvoiceResult> => {
   if (!Number.isFinite(amountSat) || amountSat <= 0) {
     throw new Error("Invalid amount");
   }
@@ -413,14 +634,36 @@ export const fetchLnurlInvoiceForTarget = async (
     asNonEmptyString(invoiceJson.paymentRequest);
   if (!pr) throw new Error("Invoice missing");
 
-  return pr;
+  // LUD-06 step 7: verify the invoice's `h` tag is sha256(utf8(metadata)) and
+  // its amount equals the user-specified millisatoshis.
+  const metadataRaw = asNonEmptyString(payReq.metadata);
+  if (metadataRaw) {
+    const invoiceHashHex = getLightningInvoiceDescriptionHashHex(pr);
+    if (invoiceHashHex) {
+      const expectedHashHex = sha256HexFromString(metadataRaw);
+      if (invoiceHashHex !== expectedHashHex) {
+        throw new Error("LNURL invoice metadata hash mismatch");
+      }
+    }
+  }
+  const invoiceMsat = parseBolt11AmountMsat(pr);
+  if (invoiceMsat !== null && invoiceMsat !== amountMsat) {
+    throw new Error(
+      `LNURL invoice amount mismatch (expected ${amountMsat} msat, got ${invoiceMsat})`,
+    );
+  }
+
+  return {
+    pr,
+    successAction: parseLnurlPaySuccessAction(invoiceJson.successAction),
+  };
 };
 
 export const fetchLnurlInvoiceForLightningAddress = async (
   lightningAddress: string,
   amountSat: number,
   comment?: string,
-): Promise<string> => {
+): Promise<LnurlPayInvoiceResult> => {
   return fetchLnurlInvoiceForTarget(lightningAddress, amountSat, comment);
 };
 

--- a/apps/web-app/src/lnurlPay.ts
+++ b/apps/web-app/src/lnurlPay.ts
@@ -407,29 +407,10 @@ const getLnurlpUrlFromLightningAddress = (lightningAddress: string): string => {
   return `https://${domain}/.well-known/lnurlp/${encodeURIComponent(user)}`;
 };
 
-const HOSTED_PROXY_LOCAL_HOSTS = new Set([
-  "app.linky.fit",
-  "localhost",
-  "127.0.0.1",
-  "0.0.0.0",
-]);
-
 const getLnurlProxyUrl = (url: string): string => {
   const proxyPath = `/api/lnurlp?url=${encodeURIComponent(url)}`;
   if (isNativePlatform()) {
     return `${HOSTED_APP_ORIGIN}${proxyPath}`;
-  }
-  if (typeof window !== "undefined") {
-    const host = String(window.location?.hostname ?? "")
-      .trim()
-      .toLowerCase();
-    // Same-origin proxy only exists on app.linky.fit and the Vite dev server.
-    // Other hosts (linky.gorrdy.cz, staging mirrors, etc.) don't proxy
-    // /api/lnurlp themselves, so route the CORS bypass through the canonical
-    // hosted origin.
-    if (host && !HOSTED_PROXY_LOCAL_HOSTS.has(host)) {
-      return `${HOSTED_APP_ORIGIN}${proxyPath}`;
-    }
   }
   return proxyPath;
 };

--- a/apps/web-app/src/pages/LnAddressPayPage.tsx
+++ b/apps/web-app/src/pages/LnAddressPayPage.tsx
@@ -1,9 +1,11 @@
-import type { FC } from "react";
+import { useEffect, useState, type FC } from "react";
 import { useAppShellCore } from "../app/context/AppShellContexts";
 import { PaymentAmountPanel } from "../components/PaymentAmountPanel";
 import {
+  fetchLnurlPayPreview,
   getLnurlPayDisplayText,
   inferLightningAddressFromLnurlTarget,
+  type LnurlPayPreview,
 } from "../lnurlPay";
 import { formatMiddleDots, getInitials } from "../utils/formatting";
 
@@ -43,6 +45,52 @@ export const LnAddressPayPage: FC<LnAddressPayPageProps> = ({
   t,
 }) => {
   const { formatDisplayedAmountText } = useAppShellCore();
+  const [previewState, setPreviewState] = useState<{
+    target: string;
+    preview: LnurlPayPreview | null;
+    error: string | null;
+  }>({ target: "", preview: null, error: null });
+
+  const target = String(lnAddress ?? "").trim();
+  const previewLoaded = previewState.target === target;
+  const previewLoading = !!target && !previewLoaded;
+  const preview = previewLoaded ? previewState.preview : null;
+  const previewError = previewLoaded ? previewState.error : null;
+
+  useEffect(() => {
+    if (!target) return;
+    let cancelled = false;
+    fetchLnurlPayPreview(target)
+      .then((next) => {
+        if (cancelled) return;
+        setPreviewState({ target, preview: next, error: null });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        const message =
+          error instanceof Error ? error.message : String(error ?? "");
+        setPreviewState({
+          target,
+          preview: null,
+          error: message || t("lnurlPayLoadFailed"),
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [target, t]);
+
+  const isFixedAmount =
+    preview !== null && preview.minSendableSat === preview.maxSendableSat;
+  const fixedAmountSat = isFixedAmount ? preview.minSendableSat : null;
+
+  useEffect(() => {
+    if (fixedAmountSat === null) return;
+    const next = String(fixedAmountSat);
+    setLnAddressPayAmount((current) => (current === next ? current : next));
+  }, [fixedAmountSat, setLnAddressPayAmount]);
+
   const amountSat = Number.parseInt(lnAddressPayAmount.trim(), 10);
   const displayTarget = formatMiddleDots(getLnurlPayDisplayText(lnAddress), 36);
   const inferredLightningAddress =
@@ -57,16 +105,92 @@ export const LnAddressPayPage: FC<LnAddressPayPageProps> = ({
   const availableAmountText = `${t("availablePrefix")} ${formatDisplayedAmountText(
     cashuBalance,
   )}`;
+
+  const minSendableSat = preview?.minSendableSat ?? null;
+  const maxSendableSat = preview?.maxSendableSat ?? null;
+
+  const amountBelowRange =
+    minSendableSat !== null &&
+    Number.isFinite(amountSat) &&
+    amountSat > 0 &&
+    amountSat < minSendableSat;
+  const amountAboveRange =
+    maxSendableSat !== null &&
+    Number.isFinite(amountSat) &&
+    amountSat > maxSendableSat;
+
   const invalid =
     !canPayWithCashu ||
     !Number.isFinite(amountSat) ||
     amountSat <= 0 ||
-    amountSat > cashuBalance;
+    amountSat > cashuBalance ||
+    previewLoading ||
+    previewError !== null ||
+    amountBelowRange ||
+    amountAboveRange;
+
+  let submitTitle: string | undefined;
+  if (amountSat > cashuBalance) {
+    submitTitle = t("payInsufficient");
+  } else if (amountBelowRange && minSendableSat !== null) {
+    submitTitle = t("lnurlPayAmountTooLow").replace(
+      "{min}",
+      String(minSendableSat),
+    );
+  } else if (amountAboveRange && maxSendableSat !== null) {
+    submitTitle = t("lnurlPayAmountTooHigh").replace(
+      "{max}",
+      String(maxSendableSat),
+    );
+  }
+
+  const renderNotices = (): React.ReactNode => {
+    if (previewLoading) {
+      return <p className="muted">{t("lnurlPayLoading")}</p>;
+    }
+    if (previewError) {
+      return (
+        <p className="muted">
+          {t("lnurlPayLoadFailed")}: {previewError}
+        </p>
+      );
+    }
+    if (!preview) return null;
+
+    const descriptionLine = preview.description ? (
+      <p className="muted">{preview.description}</p>
+    ) : null;
+
+    if (isFixedAmount) {
+      return (
+        <>
+          {descriptionLine}
+          <p className="muted">
+            {t("lnurlPayFixedHint").replace(
+              "{amount}",
+              String(preview.minSendableSat),
+            )}
+          </p>
+        </>
+      );
+    }
+
+    return (
+      <>
+        {descriptionLine}
+        <p className="muted">
+          {t("lnurlPayRangeHint")
+            .replace("{min}", String(preview.minSendableSat))
+            .replace("{max}", String(preview.maxSendableSat))}
+        </p>
+      </>
+    );
+  };
 
   return (
     <PaymentAmountPanel
       amount={lnAddressPayAmount}
-      cashuIsBusy={cashuIsBusy}
+      cashuIsBusy={cashuIsBusy || previewLoading}
       displayUnit={displayUnit}
       header={
         <div className="contact-header">
@@ -105,14 +229,14 @@ export const LnAddressPayPage: FC<LnAddressPayPageProps> = ({
           </div>
         </div>
       }
-      notices={undefined}
+      notices={renderNotices()}
       onAmountChange={setLnAddressPayAmount}
       onSubmit={() => {
         if (invalid) return;
         void payLightningAddressWithCashu(lnAddress, amountSat);
       }}
       submitDisabled={invalid}
-      submitTitle={amountSat > cashuBalance ? t("payInsufficient") : undefined}
+      submitTitle={submitTitle}
       t={t}
     />
   );

--- a/apps/web-app/src/pages/TransactionsPage.tsx
+++ b/apps/web-app/src/pages/TransactionsPage.tsx
@@ -145,6 +145,11 @@ const formatCompactToken = (value: string): string => {
   return `${value.slice(0, 12)}...${value.slice(-12)}`;
 };
 
+const formatCompactLongString = (value: string): string => {
+  if (value.length <= 20) return value;
+  return `${value.slice(0, 8)}...${value.slice(-6)}`;
+};
+
 const readRequestIdFromDetails = (details: JsonValue | null): string | null => {
   const detailRecord = readJsonRecord(details);
   return readStringFromJson(detailRecord?.requestId);
@@ -477,6 +482,22 @@ export function TransactionsPage(): React.ReactElement {
     [t],
   );
 
+  const readLnurlSuccessMessage = React.useCallback(
+    (item: TransactionItem): string | null => {
+      const details = readJsonRecord(item.details);
+      if (!details) return null;
+      const message = readStringFromJson(details.lnurlSuccessMessage);
+      if (message) return message;
+      const url = readStringFromJson(details.lnurlSuccessUrl);
+      if (!url) return null;
+      const description = readStringFromJson(
+        details.lnurlSuccessUrlDescription,
+      );
+      return description ? `${description} ${url}` : url;
+    },
+    [],
+  );
+
   const getRequestStatus = React.useCallback(
     (item: TransactionItem): "declined" | "paid" | "pending" | null => {
       if (item.note !== requestPaymentLabel) return null;
@@ -502,6 +523,13 @@ export function TransactionsPage(): React.ReactElement {
       const lightningMemo = readStringFromJson(details.lightningMemo);
       const lightningInvoice = readStringFromJson(details.lightningInvoice);
       const lightningPreimage = readStringFromJson(details.lightningPreimage);
+      const lnurlSuccessMessage = readStringFromJson(
+        details.lnurlSuccessMessage,
+      );
+      const lnurlSuccessUrl = readStringFromJson(details.lnurlSuccessUrl);
+      const lnurlSuccessUrlDescription = readStringFromJson(
+        details.lnurlSuccessUrlDescription,
+      );
 
       return [
         ...(usedTokens.length > 0
@@ -526,6 +554,29 @@ export function TransactionsPage(): React.ReactElement {
               },
             ]
           : []),
+        ...(lnurlSuccessMessage
+          ? [
+              {
+                label: t("transactionDetailLnurlSuccessMessage"),
+                values: [{ value: lnurlSuccessMessage }],
+              },
+            ]
+          : []),
+        ...(lnurlSuccessUrl
+          ? [
+              {
+                label: t("transactionDetailLnurlSuccessUrl"),
+                values: [
+                  {
+                    value: lnurlSuccessUrlDescription
+                      ? `${lnurlSuccessUrlDescription} ${lnurlSuccessUrl}`
+                      : lnurlSuccessUrl,
+                    copyValue: lnurlSuccessUrl,
+                  },
+                ],
+              },
+            ]
+          : []),
         ...(lightningMemo
           ? [
               {
@@ -538,7 +589,12 @@ export function TransactionsPage(): React.ReactElement {
           ? [
               {
                 label: t("transactionDetailLightningInvoice"),
-                values: [{ value: lightningInvoice }],
+                values: [
+                  {
+                    copyValue: lightningInvoice,
+                    value: formatCompactLongString(lightningInvoice),
+                  },
+                ],
               },
             ]
           : []),
@@ -546,7 +602,12 @@ export function TransactionsPage(): React.ReactElement {
           ? [
               {
                 label: t("transactionDetailLightningPreimage"),
-                values: [{ value: lightningPreimage }],
+                values: [
+                  {
+                    copyValue: lightningPreimage,
+                    value: formatCompactLongString(lightningPreimage),
+                  },
+                ],
               },
             ]
           : []),
@@ -636,6 +697,14 @@ export function TransactionsPage(): React.ReactElement {
                   </div>
                   <div className="transaction-main">
                     <div className="transaction-title">{buildTitle(item)}</div>
+                    {(() => {
+                      const lnurlMessage = readLnurlSuccessMessage(item);
+                      return lnurlMessage ? (
+                        <div className="transaction-subtitle">
+                          {lnurlMessage}
+                        </div>
+                      ) : null;
+                    })()}
                     <div className="transaction-meta">
                       {buildMeta(item, requestStatus)}
                     </div>

--- a/apps/web-app/src/utils/lightningInvoice.ts
+++ b/apps/web-app/src/utils/lightningInvoice.ts
@@ -8,6 +8,7 @@ const BOLT11_SIGNATURE_WORDS = 104;
 const DEFAULT_EXPIRY_SECONDS = 3_600;
 
 const DESCRIPTION_TAG = BOLT11_CHARSET.indexOf("d");
+const DESCRIPTION_HASH_TAG = BOLT11_CHARSET.indexOf("h");
 const EXPIRY_TAG = BOLT11_CHARSET.indexOf("x");
 
 export interface LightningInvoicePreview {
@@ -18,6 +19,12 @@ export interface LightningInvoicePreview {
 }
 
 const parseBolt11AmountSat = (invoice: string): number | null => {
+  const msat = parseBolt11AmountMsat(invoice);
+  if (msat === null) return null;
+  return Math.ceil(msat / 1000);
+};
+
+export const parseBolt11AmountMsat = (invoice: string): number | null => {
   const separatorIndex = invoice.lastIndexOf("1");
   if (separatorIndex <= 0) return null;
 
@@ -33,20 +40,20 @@ const parseBolt11AmountSat = (invoice: string): number | null => {
   const value = Number(digits);
   if (!Number.isFinite(value) || value <= 0) return null;
 
-  const satAmount = (() => {
-    if (!hasUnit) return value * 100_000_000;
-    if (unitSuffix === "m") return value * 100_000;
-    if (unitSuffix === "u") return value * 100;
-    if (unitSuffix === "n") return value / 10;
-    if (unitSuffix === "p") return value / 10_000;
+  const msatAmount = (() => {
+    if (!hasUnit) return value * 100_000_000_000;
+    if (unitSuffix === "m") return value * 100_000_000;
+    if (unitSuffix === "u") return value * 100_000;
+    if (unitSuffix === "n") return value * 100;
+    if (unitSuffix === "p") return value / 10;
     return null;
   })();
 
-  if (!Number.isFinite(satAmount) || satAmount === null || satAmount <= 0) {
+  if (!Number.isFinite(msatAmount) || msatAmount === null || msatAmount <= 0) {
     return null;
   }
 
-  return Math.ceil(satAmount);
+  return Math.ceil(msatAmount);
 };
 
 const parseWordNumber = (words: readonly number[]): number | null => {
@@ -128,4 +135,62 @@ export const getLightningInvoicePreview = (
   }
 
   return preview;
+};
+
+const toHex = (bytes: Uint8Array): string => {
+  let result = "";
+  for (const byte of bytes) {
+    result += byte.toString(16).padStart(2, "0");
+  }
+  return result;
+};
+
+export const getLightningInvoiceDescriptionHashHex = (
+  rawInvoice: string,
+): string | null => {
+  const invoice = String(rawInvoice ?? "").trim();
+  if (!BOLT11_PREFIX_RE.test(invoice)) return null;
+
+  try {
+    const decoded = bech32.decodeUnsafe(
+      invoice.toLowerCase(),
+      BOLT11_WORD_LIMIT,
+    );
+    if (!decoded) return null;
+
+    const { words } = decoded;
+    if (words.length < BOLT11_TIMESTAMP_WORDS + BOLT11_SIGNATURE_WORDS) {
+      return null;
+    }
+
+    const payloadWords = words.slice(
+      BOLT11_TIMESTAMP_WORDS,
+      -BOLT11_SIGNATURE_WORDS,
+    );
+
+    let offset = 0;
+    while (offset + 3 <= payloadWords.length) {
+      const tag = payloadWords[offset];
+      const dataLength = parseWordNumber(
+        payloadWords.slice(offset + 1, offset + 3),
+      );
+      if (dataLength === null) break;
+
+      const start = offset + 3;
+      const end = start + dataLength;
+      if (end > payloadWords.length) break;
+
+      if (tag === DESCRIPTION_HASH_TAG && dataLength === 52) {
+        const data = payloadWords.slice(start, end);
+        const bytes = bech32.fromWords(data);
+        if (bytes.length === 32) return toHex(bytes);
+      }
+
+      offset = end;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
 };


### PR DESCRIPTION
 ## Summary
  
  - **LUD-06 LNURL-pay**: `#payln` fetches `payRequest` on mount and branches the UI:
    - `min === max` presets the amount and asks the user to confirm.
    - `min < max` shows the allowed range and clamps invalid amounts.
    - Validates `tag`, status, min/max bounds, and that metadata contains the required `text/plain` entry.
    - After invoice fetch, verifies `h-tag` matches `sha256(utf8(metadata))` and that the BOLT11 amount equals the requested msat.
    - Collapses consecutive slashes in decoded LNURL paths (some encoders ship `https://host/lnurlp//id`, which 404s without normalization).
  - **LUD-09 successAction**: parses `message` and `url` actions on the invoice response. The message (e.g. raffle ticket numbers from `lnurld`) is shown both on
   the transactions list and as a dedicated row in the transaction detail.
  - **Transaction detail UX**: lightning invoice + preimage are truncated as `lnbc1xxx...xyz`; the row remains a copy button that copies the full original value.
  - **Autoswap melt**: before the melt-to-main-mint retry loop, probe the source mint with a trial invoice for the full source balance, read `fee_reserve +
  input_fee`, and size the first real invoice as `sourceBalance − fee_reserve − input_fee` so the first attempt has the correct headroom instead of burning the
  retry ladder on `Insufficient funds`.
  - **i18n**: new CS/EN strings for LNURL load/error/range hints, successAction display, and the new transaction-detail labels.

  Out of scope: a CORS bypass workaround for non-canonical mirror origins (e.g. `linky.gorrdy.cz`) was prototyped and reverted — mirrors should either ship their
   own `/api/lnurlp` reverse proxy or upstream LNURL servers should send `Access-Control-Allow-Origin: *`.

  ## Test plan

  - [ ] Pay a fixed-amount LNURL (`min === max`, e.g. an `lnurld` raffle ticket) — amount is preset, send works, success message renders in the status bar.
  - [ ] Pay a range-amount LNURL (`min < max`) — range hint shows, out-of-range values disable Pay.
  - [ ] Pay an LNURL whose decoded URL has `//` in the path — request resolves and succeeds.
  - [ ] Open the transaction in history — `Zpráva od příjemce` / "Message from recipient" row visible; invoice + preimage truncated; tap copies the full value.
  - [ ] Trigger autoswap from a foreign-mint balance to the main mint — first attempt sizes correctly (no `have N need N+M` retry).
  - [ ] `bun run check-code` passes.