### PR TITLE
fix(evolu): owner rotation snapshot + heal-on-adopt

### DIFF
--- a/apps/web-app/src/app/hooks/useEvoluContactsOwnerRotation.ts
+++ b/apps/web-app/src/app/hooks/useEvoluContactsOwnerRotation.ts
@@ -25,6 +25,11 @@ import {
   TRANSACTIONS_OWNER_ROTATION_TRIGGER_WRITE_COUNT,
 } from "../../utils/constants";
 import { deriveEvoluOwnerMnemonicFromSlip39 } from "../../utils/slip39Nostr";
+import {
+  decodeRotationSnapshot,
+  encodeRotationSnapshot,
+  type RotationSnapshot,
+} from "../lib/rotationSnapshot";
 import type { CashuTokenRowLike, ContactRowLike } from "../types/appTypes";
 
 type EvoluMutations = ReturnType<typeof import("../../evolu").useEvolu>;
@@ -163,64 +168,20 @@ const scoreCashuToken = (token: CashuTokenRowLike): number => {
   return score;
 };
 
-const parseContactsOwnerIndexFromPointer = (value: unknown): number | null => {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  const match = /^contacts-(\d+)$/.exec(trimmed);
-  if (!match) return null;
-  const parsed = Number(match[1]);
-  if (!Number.isFinite(parsed)) return null;
-  if (parsed < 0) return null;
-  return Math.trunc(parsed);
-};
-
-const parseCashuOwnerIndexFromPointer = (value: unknown): number | null => {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  const match = /^cashu-(\d+)$/.exec(trimmed);
-  if (!match) return null;
-  const parsed = Number(match[1]);
-  if (!Number.isFinite(parsed)) return null;
-  if (parsed < 0) return null;
-  return Math.trunc(parsed);
-};
-
-const parseMessagesOwnerIndexFromPointer = (value: unknown): number | null => {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  const match = /^messages-(\d+)$/.exec(trimmed);
-  if (!match) return null;
-  const parsed = Number(match[1]);
-  if (!Number.isFinite(parsed)) return null;
-  if (parsed < 0) return null;
-  return Math.trunc(parsed);
-};
-
-const parseTransactionsOwnerIndexFromPointer = (
-  value: unknown,
-): number | null => {
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  const match = /^transactions-(\d+)$/.exec(trimmed);
-  if (!match) return null;
-  const parsed = Number(match[1]);
-  if (!Number.isFinite(parsed)) return null;
-  if (parsed < 0) return null;
-  return Math.trunc(parsed);
-};
-
-const upsertOwnerMetaPointer = (
+const upsertOwnerMetaSnapshot = (
   upsert: EvoluMutations["upsert"],
   ownerId: Evolu.OwnerId,
   scope: "cashu" | "contacts" | "messages" | "transactions",
-  value: string,
+  snapshot: RotationSnapshot,
 ) =>
   upsert(
     "ownerMeta",
     {
       id: createMetaPointerRowId(scope),
       scope: scope as typeof Evolu.NonEmptyString100.Type,
-      value: value as typeof Evolu.NonEmptyString1000.Type,
+      value: encodeRotationSnapshot(
+        snapshot,
+      ) as typeof Evolu.NonEmptyString1000.Type,
     },
     { ownerId },
   );
@@ -880,10 +841,9 @@ export const useEvoluContactsOwnerRotation = ({
     const metaOwnerId = String(ownerSyncData.metaOwner.id).trim();
     if (!metaOwnerId) return;
 
-    let resolvedContactsIndex: number | null = null;
-    let resolvedCashuIndex: number | null = null;
-    let resolvedMessagesIndex: number | null = null;
-    let resolvedTransactionsIndex: number | null = null;
+    let contactsSnap: RotationSnapshot | null = null;
+    let messagesSnap: RotationSnapshot | null = null;
+    let transactionsSnap: RotationSnapshot | null = null;
     for (const row of ownerMetaRows) {
       if (readRowOwnerId(row) !== metaOwnerId) continue;
       const scope =
@@ -891,66 +851,125 @@ export const useEvoluContactsOwnerRotation = ({
           ? row.scope
           : null;
       const scopeText = typeof scope === "string" ? scope.trim() : "";
+      const rawValue = readRowPointerValue(row);
       if (scopeText === "contacts") {
-        const parsed = parseContactsOwnerIndexFromPointer(
-          readRowPointerValue(row),
-        );
-        if (parsed !== null) resolvedContactsIndex = parsed;
-      }
-      if (scopeText === "cashu") {
-        const parsed = parseCashuOwnerIndexFromPointer(
-          readRowPointerValue(row),
-        );
-        if (parsed !== null) resolvedCashuIndex = parsed;
-      }
-      if (scopeText === "messages") {
-        const parsed = parseMessagesOwnerIndexFromPointer(
-          readRowPointerValue(row),
-        );
-        if (parsed !== null) resolvedMessagesIndex = parsed;
-      }
-      if (scopeText === "transactions") {
-        const parsed = parseTransactionsOwnerIndexFromPointer(
-          readRowPointerValue(row),
-        );
-        if (parsed !== null) resolvedTransactionsIndex = parsed;
+        const decoded = decodeRotationSnapshot(rawValue, "contacts");
+        if (decoded) contactsSnap = decoded;
+      } else if (scopeText === "messages") {
+        const decoded = decodeRotationSnapshot(rawValue, "messages");
+        if (decoded) messagesSnap = decoded;
+      } else if (scopeText === "transactions") {
+        const decoded = decodeRotationSnapshot(rawValue, "transactions");
+        if (decoded) transactionsSnap = decoded;
       }
     }
 
-    const resolvedSharedCashuContactsIndex =
-      resolvedContactsIndex ?? resolvedCashuIndex;
+    // When adopting a rotation from another device we must reset baseline +
+    // editCount + lastRotatedAt for the new index. Otherwise the adopter
+    // sees `delta = currentRowCount - 0` once Evolu sync pulls in the
+    // migrated rows and immediately re-rotates, cascading divergent owner
+    // lanes across the fleet.
+    //
+    // JSON snapshots carry the authoritative baseline values. Legacy
+    // `<scope>-N` values lose them — we fall back to baseline=0 and prime
+    // the cooldown with `now`, which matches the existing behaviour and is
+    // the best we can do without a baseline hint from the rotator.
+    const adoptIndex = (params: {
+      indexStorageKey: string;
+      baselineStorageKey: string;
+      editCountStorageKey: string;
+      lastRotatedStorageKey: string;
+      currentIndex: number;
+      nextIndex: number;
+      baseline: number | null;
+      rotatedAtMs: number | null;
+      setCurrentIndex: (next: number) => void;
+      setLocalEditCount: (next: number) => void;
+      extra?: () => void;
+    }) => {
+      const {
+        indexStorageKey,
+        baselineStorageKey,
+        editCountStorageKey,
+        lastRotatedStorageKey,
+        currentIndex,
+        nextIndex,
+        baseline,
+        rotatedAtMs,
+        setCurrentIndex,
+        setLocalEditCount,
+        extra,
+      } = params;
+      if (nextIndex === currentIndex) return;
+      setStoredIndex(indexStorageKey, nextIndex);
+      setCounterValue(baselineStorageKey, nextIndex, baseline ?? 0);
+      setCounterValue(editCountStorageKey, nextIndex, 0);
+      setLocalEditCount(0);
+      setStoredTimestampMs(lastRotatedStorageKey, rotatedAtMs ?? Date.now());
+      setCurrentIndex(nextIndex);
+      extra?.();
+    };
 
-    if (
-      resolvedSharedCashuContactsIndex !== null &&
-      resolvedSharedCashuContactsIndex !== contactsOwnerIndex
-    ) {
-      setStoredIndex(
-        EVOLU_CONTACTS_OWNER_INDEX_STORAGE_KEY,
-        resolvedSharedCashuContactsIndex,
-      );
-      setContactsOwnerIndex(resolvedSharedCashuContactsIndex);
+    if (contactsSnap && contactsSnap.index !== contactsOwnerIndex) {
+      const snap = contactsSnap;
+      adoptIndex({
+        indexStorageKey: EVOLU_CONTACTS_OWNER_INDEX_STORAGE_KEY,
+        baselineStorageKey: EVOLU_CONTACTS_OWNER_BASELINE_COUNT_STORAGE_KEY,
+        editCountStorageKey: EVOLU_CONTACTS_OWNER_EDIT_COUNT_STORAGE_KEY,
+        lastRotatedStorageKey:
+          EVOLU_CONTACTS_OWNER_LAST_ROTATED_AT_MS_STORAGE_KEY,
+        currentIndex: contactsOwnerIndex,
+        nextIndex: snap.index,
+        baseline: snap.baseline,
+        rotatedAtMs: snap.rotatedAtMs,
+        setCurrentIndex: setContactsOwnerIndex,
+        setLocalEditCount: setContactsOwnerEditCount,
+        // Contacts + cashu rotate together. Mirror baseline / cooldown for
+        // the cashu lane keyed by the same contacts index.
+        extra: () => {
+          setCounterValue(
+            EVOLU_CASHU_OWNER_BASELINE_COUNT_STORAGE_KEY,
+            snap.index,
+            snap.cashuBaseline ?? 0,
+          );
+          setStoredTimestampMs(
+            EVOLU_CASHU_OWNER_LAST_ROTATED_AT_MS_STORAGE_KEY,
+            snap.rotatedAtMs ?? Date.now(),
+          );
+        },
+      });
     }
 
-    if (
-      resolvedMessagesIndex !== null &&
-      resolvedMessagesIndex !== messagesOwnerIndex
-    ) {
-      setStoredIndex(
-        EVOLU_MESSAGES_OWNER_INDEX_STORAGE_KEY,
-        resolvedMessagesIndex,
-      );
-      setMessagesOwnerIndex(resolvedMessagesIndex);
+    if (messagesSnap && messagesSnap.index !== messagesOwnerIndex) {
+      adoptIndex({
+        indexStorageKey: EVOLU_MESSAGES_OWNER_INDEX_STORAGE_KEY,
+        baselineStorageKey: EVOLU_MESSAGES_OWNER_BASELINE_COUNT_STORAGE_KEY,
+        editCountStorageKey: EVOLU_MESSAGES_OWNER_EDIT_COUNT_STORAGE_KEY,
+        lastRotatedStorageKey:
+          EVOLU_MESSAGES_OWNER_LAST_ROTATED_AT_MS_STORAGE_KEY,
+        currentIndex: messagesOwnerIndex,
+        nextIndex: messagesSnap.index,
+        baseline: messagesSnap.baseline,
+        rotatedAtMs: messagesSnap.rotatedAtMs,
+        setCurrentIndex: setMessagesOwnerIndex,
+        setLocalEditCount: setMessagesOwnerEditCount,
+      });
     }
 
-    if (
-      resolvedTransactionsIndex !== null &&
-      resolvedTransactionsIndex !== transactionsOwnerIndex
-    ) {
-      setStoredIndex(
-        EVOLU_TRANSACTIONS_OWNER_INDEX_STORAGE_KEY,
-        resolvedTransactionsIndex,
-      );
-      setTransactionsOwnerIndex(resolvedTransactionsIndex);
+    if (transactionsSnap && transactionsSnap.index !== transactionsOwnerIndex) {
+      adoptIndex({
+        indexStorageKey: EVOLU_TRANSACTIONS_OWNER_INDEX_STORAGE_KEY,
+        baselineStorageKey: EVOLU_TRANSACTIONS_OWNER_BASELINE_COUNT_STORAGE_KEY,
+        editCountStorageKey: EVOLU_TRANSACTIONS_OWNER_EDIT_COUNT_STORAGE_KEY,
+        lastRotatedStorageKey:
+          EVOLU_TRANSACTIONS_OWNER_LAST_ROTATED_AT_MS_STORAGE_KEY,
+        currentIndex: transactionsOwnerIndex,
+        nextIndex: transactionsSnap.index,
+        baseline: transactionsSnap.baseline,
+        rotatedAtMs: transactionsSnap.rotatedAtMs,
+        setCurrentIndex: setTransactionsOwnerIndex,
+        setLocalEditCount: setTransactionsOwnerEditCount,
+      });
     }
   }, [
     contactsOwnerIndex,
@@ -1219,30 +1238,26 @@ export const useEvoluContactsOwnerRotation = ({
         if (result.ok) copiedCashuCount += 1;
       }
 
-      const contactsPointerResult = upsertOwnerMetaPointer(
+      // Encode the full rotation snapshot — adopters need baseline +
+      // cashuBaseline + rotatedAtMs so their local delta calculation
+      // starts at 0 and the cooldown blocks an immediate re-rotation.
+      // Legacy adopters that only know how to parse `contacts-N` ignore
+      // the extra fields (the decoder fallback gives them null).
+      const contactsPointerResult = upsertOwnerMetaSnapshot(
         upsert,
         derived.metaOwner.id,
         "contacts",
-        `contacts-${nextIndex}`,
-      );
-
-      const cashuPointerResult = upsertOwnerMetaPointer(
-        upsert,
-        derived.metaOwner.id,
-        "cashu",
-        `cashu-${nextIndex}`,
+        {
+          index: nextIndex,
+          baseline: copiedCount,
+          cashuBaseline: copiedCashuCount,
+          rotatedAtMs: nowMs,
+        },
       );
 
       if (!contactsPointerResult.ok) {
         pushToast(
           `${t("errorPrefix")}: ${formatMutationError(contactsPointerResult.error)}`,
-        );
-        return;
-      }
-
-      if (!cashuPointerResult.ok) {
-        pushToast(
-          `${t("errorPrefix")}: ${formatMutationError(cashuPointerResult.error)}`,
         );
         return;
       }
@@ -1414,11 +1429,18 @@ export const useEvoluContactsOwnerRotation = ({
         return;
       }
 
-      const pointerResult = upsertOwnerMetaPointer(
+      // Messages rotation is pointer-only (no row copy), so baseline = 0
+      // for the new lane. rotatedAtMs primes the adopter's cooldown.
+      const pointerResult = upsertOwnerMetaSnapshot(
         upsert,
         derived.metaOwner.id,
         "messages",
-        `messages-${nextIndex}`,
+        {
+          index: nextIndex,
+          baseline: 0,
+          cashuBaseline: null,
+          rotatedAtMs: nowMs,
+        },
       );
 
       if (!pointerResult.ok) {
@@ -1591,11 +1613,19 @@ export const useEvoluContactsOwnerRotation = ({
         return;
       }
 
-      const pointerResult = upsertOwnerMetaPointer(
+      // Transactions rotation is pointer-only (no row copy). Baseline =
+      // 0 + rotatedAtMs primes the adopter's cooldown so it doesn't
+      // re-rotate when Evolu sync floods rows into the new lane.
+      const pointerResult = upsertOwnerMetaSnapshot(
         upsert,
         derived.metaOwner.id,
         "transactions",
-        `transactions-${nextIndex}`,
+        {
+          index: nextIndex,
+          baseline: 0,
+          cashuBaseline: null,
+          rotatedAtMs: nowMs,
+        },
       );
 
       if (!pointerResult.ok) {

--- a/apps/web-app/src/app/hooks/useEvoluContactsOwnerRotation.ts
+++ b/apps/web-app/src/app/hooks/useEvoluContactsOwnerRotation.ts
@@ -835,6 +835,268 @@ export const useEvoluContactsOwnerRotation = ({
     transactionsOwnerIndex,
   ]);
 
+  // Heal-on-adopt: when the reconciler below adopts a higher index from
+  // another device's rotation, this device's local lane (at the OLD lower
+  // index) may still hold rows that the rotating device never saw. Without
+  // healing, those rows stay orphaned in the old lane and disappear from
+  // the active UI. Copy them forward by re-upserting (id-keyed, so Evolu's
+  // last-write-wins keeps the latest version of any row also touched by
+  // the rotator). Fire-and-forget — failures are non-fatal; subsequent
+  // rotations re-attempt the copy by the same logic.
+  const healAdoptedContactsAndCashuRef = React.useRef<
+    (args: { seed: string; fromIndex: number; toIndex: number }) => void
+  >(() => {});
+  const healAdoptedMessagesRef = React.useRef<
+    (args: { seed: string; fromIndex: number; toIndex: number }) => void
+  >(() => {});
+  const healAdoptedTransactionsRef = React.useRef<
+    (args: { seed: string; fromIndex: number; toIndex: number }) => void
+  >(() => {});
+
+  // Refresh the heal callbacks on every render so they close over the
+  // latest row data + index state. Using refs (vs putting these in the
+  // reconciler deps) keeps the reconciler effect from churning every time
+  // a row syncs in.
+  healAdoptedContactsAndCashuRef.current = ({
+    seed,
+    fromIndex,
+    toIndex,
+  }: {
+    seed: string;
+    fromIndex: number;
+    toIndex: number;
+  }) => {
+    if (fromIndex === toIndex) return;
+    const normalizedSeed = String(seed ?? "").trim();
+    if (!normalizedSeed) return;
+
+    void (async () => {
+      const fromDerived = await deriveContactsAndCashuOwnersFromSeed(
+        normalizedSeed,
+        fromIndex,
+      );
+      const toDerived = await deriveContactsAndCashuOwnersFromSeed(
+        normalizedSeed,
+        toIndex,
+      );
+      if (!fromDerived || !toDerived) return;
+
+      const fromContactsOwnerId = String(fromDerived.contactsOwner.id).trim();
+      const fromCashuOwnerId = String(fromDerived.cashuOwner.id).trim();
+
+      for (const row of allContactsRows) {
+        if (readRowOwnerId(row) !== fromContactsOwnerId) continue;
+        if (
+          typeof row !== "object" ||
+          row === null ||
+          !("id" in row) ||
+          typeof row.id !== "string"
+        ) {
+          continue;
+        }
+        const id = row.id.trim();
+        if (!id) continue;
+        const contact = row as ContactRowLike & { id: string };
+        const name = String(contact.name ?? "").trim();
+        const npub = String(contact.npub ?? "").trim();
+        const lnAddress = String(contact.lnAddress ?? "").trim();
+        const groupName = String(contact.groupName ?? "").trim();
+        if (!name && !npub && !lnAddress && !groupName) continue;
+        upsert(
+          "contact",
+          {
+            id: id as ContactId,
+            name: name ? (name as typeof Evolu.NonEmptyString1000.Type) : null,
+            npub: npub ? (npub as typeof Evolu.NonEmptyString1000.Type) : null,
+            lnAddress: lnAddress
+              ? (lnAddress as typeof Evolu.NonEmptyString1000.Type)
+              : null,
+            groupName: groupName
+              ? (groupName as typeof Evolu.NonEmptyString1000.Type)
+              : null,
+          },
+          { ownerId: toDerived.contactsOwner.id },
+        );
+      }
+
+      for (const row of allCashuTokensRows) {
+        if (readRowOwnerId(row) !== fromCashuOwnerId) continue;
+        const tokenId = readCashuTokenId(row);
+        const tokenText = readCashuTokenValue(row);
+        if (!tokenId || !tokenText) continue;
+        const payload: {
+          id: CashuTokenId;
+          token: typeof Evolu.NonEmptyString.Type;
+          amount?: typeof Evolu.PositiveInt.Type;
+          error?: typeof Evolu.NonEmptyString1000.Type;
+          mint?: typeof Evolu.NonEmptyString1000.Type;
+          rawToken?: typeof Evolu.NonEmptyString.Type;
+          state?: typeof Evolu.NonEmptyString100.Type;
+          unit?: typeof Evolu.NonEmptyString100.Type;
+        } = {
+          id: tokenId as CashuTokenId,
+          token: tokenText as typeof Evolu.NonEmptyString.Type,
+        };
+        const rawToken =
+          typeof row === "object" && row !== null && "rawToken" in row
+            ? readCashuOptionalText(row.rawToken)
+            : null;
+        if (rawToken)
+          payload.rawToken = rawToken as typeof Evolu.NonEmptyString.Type;
+        const mint =
+          typeof row === "object" && row !== null && "mint" in row
+            ? readCashuOptionalText(row.mint)
+            : null;
+        if (mint) payload.mint = mint as typeof Evolu.NonEmptyString1000.Type;
+        const unit =
+          typeof row === "object" && row !== null && "unit" in row
+            ? readCashuOptionalText(row.unit)
+            : null;
+        if (unit) payload.unit = unit as typeof Evolu.NonEmptyString100.Type;
+        const amount =
+          typeof row === "object" && row !== null && "amount" in row
+            ? readCashuOptionalAmount(row.amount)
+            : null;
+        if (amount && amount > 0)
+          payload.amount = amount as typeof Evolu.PositiveInt.Type;
+        const stateText =
+          typeof row === "object" && row !== null && "state" in row
+            ? readCashuOptionalText(row.state)
+            : null;
+        if (stateText)
+          payload.state = stateText as typeof Evolu.NonEmptyString100.Type;
+        const errorText =
+          typeof row === "object" && row !== null && "error" in row
+            ? readCashuOptionalText(row.error)
+            : null;
+        if (errorText)
+          payload.error = errorText as typeof Evolu.NonEmptyString1000.Type;
+        upsert("cashuToken", payload, {
+          ownerId: toDerived.cashuOwner.id,
+        });
+      }
+    })();
+  };
+
+  healAdoptedMessagesRef.current = ({
+    seed,
+    fromIndex,
+    toIndex,
+  }: {
+    seed: string;
+    fromIndex: number;
+    toIndex: number;
+  }) => {
+    if (fromIndex === toIndex) return;
+    const normalizedSeed = String(seed ?? "").trim();
+    if (!normalizedSeed) return;
+
+    void (async () => {
+      const fromMnemonic = await deriveEvoluOwnerMnemonicFromSlip39(
+        normalizedSeed,
+        "messages",
+        fromIndex,
+      );
+      const toMnemonic = await deriveEvoluOwnerMnemonicFromSlip39(
+        normalizedSeed,
+        "messages",
+        toIndex,
+      );
+      if (!fromMnemonic || !toMnemonic) return;
+      const fromOwner = toAppOwnerFromMnemonic(fromMnemonic);
+      const toOwner = toAppOwnerFromMnemonic(toMnemonic);
+      if (!fromOwner || !toOwner) return;
+      const fromOwnerId = String(fromOwner.id).trim();
+
+      for (const row of allNostrMessagesRows) {
+        if (readRowOwnerId(row) !== fromOwnerId) continue;
+        if (
+          typeof row !== "object" ||
+          row === null ||
+          !("id" in row) ||
+          typeof row.id !== "string"
+        ) {
+          continue;
+        }
+        // Re-upsert the row payload into the new lane. We let Evolu
+        // schema validation drop any fields that don't apply — but the
+        // row already conformed when first written, so the payload is a
+        // shape-preserving copy.
+        const payload = { ...row } as Record<string, unknown>;
+        delete payload.ownerId;
+        upsert("nostrMessage", payload as never, {
+          ownerId: toOwner.id,
+        });
+      }
+
+      for (const row of allNostrReactionsRows) {
+        if (readRowOwnerId(row) !== fromOwnerId) continue;
+        if (
+          typeof row !== "object" ||
+          row === null ||
+          !("id" in row) ||
+          typeof row.id !== "string"
+        ) {
+          continue;
+        }
+        const payload = { ...row } as Record<string, unknown>;
+        delete payload.ownerId;
+        upsert("nostrReaction", payload as never, {
+          ownerId: toOwner.id,
+        });
+      }
+    })();
+  };
+
+  healAdoptedTransactionsRef.current = ({
+    seed,
+    fromIndex,
+    toIndex,
+  }: {
+    seed: string;
+    fromIndex: number;
+    toIndex: number;
+  }) => {
+    if (fromIndex === toIndex) return;
+    const normalizedSeed = String(seed ?? "").trim();
+    if (!normalizedSeed) return;
+
+    void (async () => {
+      const fromMnemonic = await deriveEvoluOwnerMnemonicFromSlip39(
+        normalizedSeed,
+        "transactions",
+        fromIndex,
+      );
+      const toMnemonic = await deriveEvoluOwnerMnemonicFromSlip39(
+        normalizedSeed,
+        "transactions",
+        toIndex,
+      );
+      if (!fromMnemonic || !toMnemonic) return;
+      const fromOwner = toAppOwnerFromMnemonic(fromMnemonic);
+      const toOwner = toAppOwnerFromMnemonic(toMnemonic);
+      if (!fromOwner || !toOwner) return;
+      const fromOwnerId = String(fromOwner.id).trim();
+
+      for (const row of allTransactionsRows) {
+        if (readRowOwnerId(row) !== fromOwnerId) continue;
+        if (
+          typeof row !== "object" ||
+          row === null ||
+          !("id" in row) ||
+          typeof row.id !== "string"
+        ) {
+          continue;
+        }
+        const payload = { ...row } as Record<string, unknown>;
+        delete payload.ownerId;
+        upsert("transaction", payload as never, {
+          ownerId: toOwner.id,
+        });
+      }
+    })();
+  };
+
   React.useEffect(() => {
     if (!ownerSyncData) return;
 
@@ -910,8 +1172,11 @@ export const useEvoluContactsOwnerRotation = ({
       extra?.();
     };
 
+    const normalizedSeed = String(slip39Seed ?? "").trim();
+
     if (contactsSnap && contactsSnap.index !== contactsOwnerIndex) {
       const snap = contactsSnap;
+      const fromContactsIndex = contactsOwnerIndex;
       adoptIndex({
         indexStorageKey: EVOLU_CONTACTS_OWNER_INDEX_STORAGE_KEY,
         baselineStorageKey: EVOLU_CONTACTS_OWNER_BASELINE_COUNT_STORAGE_KEY,
@@ -938,9 +1203,17 @@ export const useEvoluContactsOwnerRotation = ({
           );
         },
       });
+      if (normalizedSeed) {
+        healAdoptedContactsAndCashuRef.current({
+          seed: normalizedSeed,
+          fromIndex: fromContactsIndex,
+          toIndex: contactsSnap.index,
+        });
+      }
     }
 
     if (messagesSnap && messagesSnap.index !== messagesOwnerIndex) {
+      const fromMessagesIndex = messagesOwnerIndex;
       adoptIndex({
         indexStorageKey: EVOLU_MESSAGES_OWNER_INDEX_STORAGE_KEY,
         baselineStorageKey: EVOLU_MESSAGES_OWNER_BASELINE_COUNT_STORAGE_KEY,
@@ -954,9 +1227,17 @@ export const useEvoluContactsOwnerRotation = ({
         setCurrentIndex: setMessagesOwnerIndex,
         setLocalEditCount: setMessagesOwnerEditCount,
       });
+      if (normalizedSeed) {
+        healAdoptedMessagesRef.current({
+          seed: normalizedSeed,
+          fromIndex: fromMessagesIndex,
+          toIndex: messagesSnap.index,
+        });
+      }
     }
 
     if (transactionsSnap && transactionsSnap.index !== transactionsOwnerIndex) {
+      const fromTransactionsIndex = transactionsOwnerIndex;
       adoptIndex({
         indexStorageKey: EVOLU_TRANSACTIONS_OWNER_INDEX_STORAGE_KEY,
         baselineStorageKey: EVOLU_TRANSACTIONS_OWNER_BASELINE_COUNT_STORAGE_KEY,
@@ -970,12 +1251,20 @@ export const useEvoluContactsOwnerRotation = ({
         setCurrentIndex: setTransactionsOwnerIndex,
         setLocalEditCount: setTransactionsOwnerEditCount,
       });
+      if (normalizedSeed) {
+        healAdoptedTransactionsRef.current({
+          seed: normalizedSeed,
+          fromIndex: fromTransactionsIndex,
+          toIndex: transactionsSnap.index,
+        });
+      }
     }
   }, [
     contactsOwnerIndex,
     messagesOwnerIndex,
     ownerMetaRows,
     ownerSyncData,
+    slip39Seed,
     transactionsOwnerIndex,
   ]);
 

--- a/apps/web-app/src/app/lib/rotationSnapshot.test.ts
+++ b/apps/web-app/src/app/lib/rotationSnapshot.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeRotationSnapshot,
+  encodeRotationSnapshot,
+} from "./rotationSnapshot";
+
+describe("rotationSnapshot", () => {
+  describe("encode + decode round trip", () => {
+    it("preserves contacts snapshot with cashuBaseline", () => {
+      const snap = {
+        index: 3,
+        baseline: 800,
+        cashuBaseline: 42,
+        rotatedAtMs: 1_716_250_000_000,
+      } as const;
+      const encoded = encodeRotationSnapshot(snap);
+      expect(decodeRotationSnapshot(encoded, "contacts")).toEqual(snap);
+    });
+
+    it("preserves messages snapshot (no cashuBaseline)", () => {
+      const snap = {
+        index: 2,
+        baseline: 0,
+        cashuBaseline: null,
+        rotatedAtMs: 1_716_250_000_000,
+      } as const;
+      const encoded = encodeRotationSnapshot(snap);
+      expect(decodeRotationSnapshot(encoded, "messages")).toEqual(snap);
+    });
+
+    it("preserves transactions snapshot", () => {
+      const snap = {
+        index: 5,
+        baseline: 1234,
+        cashuBaseline: null,
+        rotatedAtMs: 1_716_300_000_000,
+      } as const;
+      const encoded = encodeRotationSnapshot(snap);
+      expect(decodeRotationSnapshot(encoded, "transactions")).toEqual(snap);
+    });
+
+    it("strips cashuBaseline when decoded under a non-contacts scope", () => {
+      const encoded = encodeRotationSnapshot({
+        index: 4,
+        baseline: 7,
+        cashuBaseline: 9,
+        rotatedAtMs: 1_716_400_000_000,
+      });
+      expect(decodeRotationSnapshot(encoded, "messages")).toEqual({
+        index: 4,
+        baseline: 7,
+        cashuBaseline: null,
+        rotatedAtMs: 1_716_400_000_000,
+      });
+    });
+
+    it("omits null fields from the encoded JSON to keep it compact", () => {
+      const encoded = encodeRotationSnapshot({
+        index: 1,
+        baseline: null,
+        cashuBaseline: null,
+        rotatedAtMs: null,
+      });
+      expect(encoded).toBe('{"index":1}');
+    });
+  });
+
+  describe("legacy format", () => {
+    it("decodes contacts-N", () => {
+      expect(decodeRotationSnapshot("contacts-3", "contacts")).toEqual({
+        index: 3,
+        baseline: null,
+        cashuBaseline: null,
+        rotatedAtMs: null,
+      });
+    });
+
+    it("decodes messages-N", () => {
+      expect(decodeRotationSnapshot("messages-7", "messages")).toEqual({
+        index: 7,
+        baseline: null,
+        cashuBaseline: null,
+        rotatedAtMs: null,
+      });
+    });
+
+    it("decodes transactions-N", () => {
+      expect(decodeRotationSnapshot("transactions-12", "transactions")).toEqual(
+        {
+          index: 12,
+          baseline: null,
+          cashuBaseline: null,
+          rotatedAtMs: null,
+        },
+      );
+    });
+
+    it("rejects legacy values whose scope prefix doesn't match", () => {
+      expect(decodeRotationSnapshot("messages-3", "contacts")).toBeNull();
+      expect(decodeRotationSnapshot("contacts-3", "messages")).toBeNull();
+    });
+
+    it("trims surrounding whitespace", () => {
+      expect(decodeRotationSnapshot("  contacts-3  ", "contacts")).toEqual({
+        index: 3,
+        baseline: null,
+        cashuBaseline: null,
+        rotatedAtMs: null,
+      });
+    });
+  });
+
+  describe("invalid input", () => {
+    it("returns null for non-string input", () => {
+      expect(decodeRotationSnapshot(null, "contacts")).toBeNull();
+      expect(decodeRotationSnapshot(undefined, "contacts")).toBeNull();
+      expect(decodeRotationSnapshot(42, "contacts")).toBeNull();
+    });
+
+    it("returns null for empty string", () => {
+      expect(decodeRotationSnapshot("", "contacts")).toBeNull();
+      expect(decodeRotationSnapshot("   ", "contacts")).toBeNull();
+    });
+
+    it("returns null for unparseable JSON-looking input", () => {
+      expect(decodeRotationSnapshot("{garbage", "contacts")).toBeNull();
+    });
+
+    it("returns null when index is missing or negative", () => {
+      expect(decodeRotationSnapshot('{"baseline":5}', "contacts")).toBeNull();
+      expect(decodeRotationSnapshot('{"index":-1}', "contacts")).toBeNull();
+      expect(decodeRotationSnapshot('{"index":"3"}', "contacts")).toBeNull();
+    });
+
+    it("ignores invalid numeric fields and treats them as null", () => {
+      expect(
+        decodeRotationSnapshot(
+          '{"index":3,"baseline":"bad","cashuBaseline":-1,"rotatedAtMs":0}',
+          "contacts",
+        ),
+      ).toEqual({
+        index: 3,
+        baseline: null,
+        cashuBaseline: null,
+        rotatedAtMs: null,
+      });
+    });
+
+    it("rejects fully malformed strings", () => {
+      expect(decodeRotationSnapshot("hello world", "contacts")).toBeNull();
+      expect(decodeRotationSnapshot("contacts-abc", "contacts")).toBeNull();
+    });
+  });
+});

--- a/apps/web-app/src/app/lib/rotationSnapshot.ts
+++ b/apps/web-app/src/app/lib/rotationSnapshot.ts
@@ -1,0 +1,108 @@
+// Cross-device propagation of owner-lane rotations. Each rotation writes
+// one row to the synced `ownerMeta` table (one row per scope) so adopters
+// can converge on the same (index, baseline, cashuBaseline, rotatedAtMs)
+// snapshot.
+//
+// Historically the `value` column was a plain `"contacts-N"` string carrying
+// only the index. Adopters then defaulted baseline / editCount / rotatedAt
+// to zero, which made `delta = currentRowCount` after Evolu sync pulled in
+// the migrated rows — large enough to fire the auto-rotation threshold a
+// second time on the adopting device, cascading rotations across the fleet.
+//
+// The structured snapshot below fixes that. Legacy `"contacts-N"` values
+// still parse (with the missing fields nulled), so old clients keep working
+// while new clients reap the full benefit.
+
+export type RotationScope = "contacts" | "messages" | "transactions";
+
+export interface RotationSnapshot {
+  /** New owner lane index (e.g. 3 → owner derivation path uses `<scope>-3`). */
+  index: number;
+  /**
+   * Row count copied forward into the new lane at rotation time. Null when
+   * decoding a legacy `"<scope>-N"` value that didn't carry baseline info;
+   * callers must then fall back to a local snapshot.
+   */
+  baseline: number | null;
+  /**
+   * Contacts scope only: cashu rows copied forward in the same rotation
+   * (contacts + cashu rotate together). Null on non-contacts scopes and on
+   * legacy values.
+   */
+  cashuBaseline: number | null;
+  /** Wall-clock timestamp the rotation completed. Null on legacy values. */
+  rotatedAtMs: number | null;
+}
+
+const LEGACY_REGEX: Record<RotationScope, RegExp> = {
+  contacts: /^contacts-(\d+)$/,
+  messages: /^messages-(\d+)$/,
+  transactions: /^transactions-(\d+)$/,
+};
+
+const sanitizeNonNegativeInt = (value: unknown): number | null => {
+  if (typeof value !== "number") return null;
+  if (!Number.isFinite(value)) return null;
+  const truncated = Math.trunc(value);
+  if (truncated < 0) return null;
+  return truncated;
+};
+
+const sanitizePositiveInt = (value: unknown): number | null => {
+  if (typeof value !== "number") return null;
+  if (!Number.isFinite(value)) return null;
+  const truncated = Math.trunc(value);
+  if (truncated <= 0) return null;
+  return truncated;
+};
+
+export const encodeRotationSnapshot = (snap: RotationSnapshot): string => {
+  const payload: Record<string, number> = { index: snap.index };
+  if (snap.baseline !== null) payload.baseline = snap.baseline;
+  if (snap.cashuBaseline !== null) payload.cashuBaseline = snap.cashuBaseline;
+  if (snap.rotatedAtMs !== null) payload.rotatedAtMs = snap.rotatedAtMs;
+  return JSON.stringify(payload);
+};
+
+export const decodeRotationSnapshot = (
+  value: unknown,
+  scope: RotationScope,
+): RotationSnapshot | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  // New format: JSON object. Start-byte check keeps the parse off the hot
+  // path for legacy values.
+  if (trimmed.startsWith("{")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return null;
+    }
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const obj = parsed as Record<string, unknown>;
+    const index = sanitizeNonNegativeInt(obj.index);
+    if (index === null) return null;
+    return {
+      index,
+      baseline: sanitizeNonNegativeInt(obj.baseline),
+      cashuBaseline:
+        scope === "contacts" ? sanitizeNonNegativeInt(obj.cashuBaseline) : null,
+      rotatedAtMs: sanitizePositiveInt(obj.rotatedAtMs),
+    };
+  }
+
+  // Legacy format: `"<scope>-<index>"`.
+  const match = LEGACY_REGEX[scope].exec(trimmed);
+  if (!match) return null;
+  const index = sanitizeNonNegativeInt(Number(match[1]));
+  if (index === null) return null;
+  return {
+    index,
+    baseline: null,
+    cashuBaseline: null,
+    rotatedAtMs: null,
+  };
+};


### PR DESCRIPTION
## Summary

Two fixes for cross-device owner-lane rotation desync. Without these, two devices that rotate independently end up on different `contacts-N` / `cashu-N` lanes and silently diverge — visible as "delete token on mobile, desktop still shows it".

### `8505258` propagate full rotation snapshot across devices

`ownerMeta.value` used to be just `"<scope>-N"`. Adopting devices updated their local `*OwnerIndex` but never wrote a baseline / editCount / lastRotatedAtMs for the new index — those defaulted to 0. As soon as Evolu sync pulled the migrated rows into the new lane, `delta = currentRowCount - 0 = full migrated count` tripped the rotation threshold again, triggering a **second rotation on the adopter**, which the original device then adopted, and so on. Different devices ended up on different lanes.

Promote `ownerMeta.value` to a structured snapshot encoded as JSON:

```
{ index, baseline, cashuBaseline?, rotatedAtMs }
```

- `apps/web-app/src/app/lib/rotationSnapshot.ts` owns the encoder / decoder. Legacy `"<scope>-N"` values still parse (with null baseline) so old clients keep working.
- All three rotation paths (contacts+cashu, messages, transactions) now write the encoded snapshot. Contacts also carries `cashuBaseline` because cashu rides on the contacts index.
- The reconciler effect adopts atomically: index + baseline + editCount=0 + lastRotatedAtMs. Cooldown on the adopter starts at the rotator's `rotatedAtMs`, which blocks the cascade re-rotation window.

### `33f4bb1` heal orphan-lane data on owner rotation adoption

Adopting a higher owner index from another device used to leave rows the adopter held in its own (now-older) lane orphaned — the rotator only migrated rows it could see locally, so anything the adopter had pending in the old lane disappeared from the active UI.

Add three fire-and-forget heal callbacks that the reconciler triggers right after adopting a higher index per scope:

- **contacts + cashu** — derive both old and new owners from the seed, re-upsert every non-deleted row owned by the old contacts / cashu owner into the new lane.
- **messages + reactions** — copy nostrMessage + nostrReaction rows from the old messages owner to the new one.
- **transactions** — copy transaction rows from the old transactions owner to the new one.

Upserts are id-keyed, so Evolu's last-write-wins keeps the rotator's newer version of any row also touched by the migration.

## Test plan

- [x] `bun run check-code` passes.
- [x] `rotationSnapshot.test.ts` (16 tests) passes.
- [ ] Two devices logged into the same SLIP-39 seed: change something on device A (delete a token), it reflects on device B within a few seconds.
- [ ] Manually rotate contacts owner on device A from `#evolu-data` — device B adopts the new index, heals any local data from its prior lane, no cascade re-rotation.

## Related

- Diagnosis from a real user: two devices had different `contactsOwnerIndex` / `cashuOwnerIndex` because `ownerMeta` never got a rotation snapshot written (legacy data, no rotation occurred post pointer-feature deploy). Manual rotation triggered the snapshot write and convergence happened via heal-on-adopt.
- Follow-up PR will add auto-write of a current snapshot at boot when one is missing — that completes the bootstrap path for pre-pointer users.