### PR TITLE
feat(cashu): add Delete spent action on Tokens page

### DIFF
--- a/apps/web-app/src/app/lib/cashuTokenState.ts
+++ b/apps/web-app/src/app/lib/cashuTokenState.ts
@@ -55,3 +55,33 @@ export const isCashuTokenEmittedState = (value: unknown): boolean => {
 
 export const isCashuTokenUnavailableState = (value: unknown): boolean =>
   isCashuTokenEmittedState(value) || isCashuTokenReservedState(value);
+
+export const isCashuTokenErrorState = (value: unknown): boolean =>
+  normalizeCashuTokenState(value) === CASHU_TOKEN_STATE_ERROR;
+
+// Error messages on cashuToken rows that signal the proofs are definitively
+// dead at the mint — the user can safely purge these from local storage.
+// Mirrors the patterns checked by `useCashuTokenChecks` when deciding whether
+// a row is unrecoverable.
+const SPENT_OR_INVALID_ERROR_PATTERNS: readonly string[] = [
+  "token already spent",
+  "proofs already spent",
+  "invalid proof",
+  "invalid proofs",
+  "token proofs missing",
+  "invalid token",
+];
+
+export const isCashuTokenDefinitivelySpent = (token: {
+  state?: unknown;
+  error?: unknown;
+}): boolean => {
+  if (!isCashuTokenErrorState(token.state)) return false;
+  const errorText = String(token.error ?? "")
+    .trim()
+    .toLowerCase();
+  if (!errorText) return false;
+  return SPENT_OR_INVALID_ERROR_PATTERNS.some((pattern) =>
+    errorText.includes(pattern),
+  );
+};

--- a/apps/web-app/src/app/routes/props/buildMoneyRouteProps.ts
+++ b/apps/web-app/src/app/routes/props/buildMoneyRouteProps.ts
@@ -22,6 +22,9 @@ interface BuildMoneyRoutePropsParams {
     MoneyRoutesProps["cashuTokenProps"]
   >["cashuTokensAll"];
   cashuOwnTokens: MoneyRoutesProps["cashuTokensProps"]["cashuOwnTokens"];
+  cashuOwnSpentTokensCount: MoneyRoutesProps["cashuTokensProps"]["cashuOwnSpentTokensCount"];
+  deleteSpentCashuTokens: MoneyRoutesProps["cashuTokensProps"]["deleteSpentCashuTokens"];
+  deleteSpentCashuTokensIsBusy: MoneyRoutesProps["cashuTokensProps"]["deleteSpentCashuTokensIsBusy"];
   checkAllCashuTokensAndDeleteInvalid: MoneyRoutesProps["cashuTokensProps"]["checkAllCashuTokensAndDeleteInvalid"];
   checkAndRefreshCashuToken: ReturnType<
     MoneyRoutesProps["cashuTokenProps"]
@@ -105,6 +108,9 @@ export const buildMoneyRouteProps = ({
   cashuMeltToMainMintButtonLabel,
   cashuTokensAll,
   cashuOwnTokens,
+  cashuOwnSpentTokensCount,
+  deleteSpentCashuTokens,
+  deleteSpentCashuTokensIsBusy,
   checkAllCashuTokensAndDeleteInvalid,
   checkAndRefreshCashuToken,
   checkIssuedCashuTokensAndDeleteClaimed,
@@ -176,6 +182,9 @@ export const buildMoneyRouteProps = ({
       cashuIssuedTokens,
       cashuMeltToMainMintButtonLabel,
       cashuOwnTokens,
+      cashuOwnSpentTokensCount,
+      deleteSpentCashuTokens,
+      deleteSpentCashuTokensIsBusy,
       checkAllCashuTokensAndDeleteInvalid,
       checkIssuedCashuTokensAndDeleteClaimed,
       getMintIconUrl,

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -221,6 +221,7 @@ import {
   CASHU_TOKEN_STATE_EXTERNALIZED,
   CASHU_TOKEN_STATE_RESERVED,
   isCashuTokenAcceptedState,
+  isCashuTokenDefinitivelySpent,
   isCashuTokenEmittedState,
   isCashuTokenIssuedState,
   isCashuTokenReservedState,
@@ -2863,6 +2864,54 @@ export const useAppShellComposition = () => {
       ),
     [cashuTokensWithMeta],
   );
+
+  const cashuOwnSpentTokens = React.useMemo(
+    () =>
+      cashuOwnTokens.filter((token) =>
+        isCashuTokenDefinitivelySpent({
+          state: token.state,
+          error: token.error,
+        }),
+      ),
+    [cashuOwnTokens],
+  );
+
+  const [deleteSpentCashuTokensIsBusy, setDeleteSpentCashuTokensIsBusy] =
+    useState(false);
+  const deleteSpentCashuTokens = React.useCallback(async () => {
+    if (deleteSpentCashuTokensIsBusy) return;
+    const targets = cashuOwnSpentTokens
+      .map((token) => token.id)
+      .filter((id): id is CashuTokenId => Boolean(id));
+    if (targets.length === 0) return;
+
+    setDeleteSpentCashuTokensIsBusy(true);
+    try {
+      const ownerId = await resolveOwnerIdForWrite();
+      let deleted = 0;
+      for (const id of targets) {
+        const payload = { id, isDeleted: Evolu.sqliteTrue };
+        const result = ownerId
+          ? update("cashuToken", payload, { ownerId })
+          : update("cashuToken", payload);
+        if (result.ok) deleted += 1;
+      }
+      if (deleted > 0) {
+        setStatus(
+          t("cashuDeleteSpentDone").replace("{count}", String(deleted)),
+        );
+      }
+    } finally {
+      setDeleteSpentCashuTokensIsBusy(false);
+    }
+  }, [
+    cashuOwnSpentTokens,
+    deleteSpentCashuTokensIsBusy,
+    resolveOwnerIdForWrite,
+    setStatus,
+    t,
+    update,
+  ]);
 
   const canPayWithCashu = cashuBalance > 0;
 
@@ -6997,6 +7046,9 @@ export const useAppShellComposition = () => {
       cashuMeltToMainMintButtonLabel,
       cashuTokensAll: cashuTokensAllFiltered,
       cashuOwnTokens,
+      cashuOwnSpentTokensCount: cashuOwnSpentTokens.length,
+      deleteSpentCashuTokens,
+      deleteSpentCashuTokensIsBusy,
       checkAllCashuTokensAndDeleteInvalid,
       checkAndRefreshCashuToken,
       checkIssuedCashuTokensAndDeleteClaimed,

--- a/apps/web-app/src/i18n/cs.ts
+++ b/apps/web-app/src/i18n/cs.ts
@@ -545,6 +545,8 @@ export const cs = {
   cashuCheckToken: "Zkontrolovat token",
   cashuCheckAllTokens: "Zkontrolovat vše",
   cashuCheckIssuedTokens: "Zkontrolovat využité",
+  cashuDeleteSpentTokens: "Smazat utracené ({count})",
+  cashuDeleteSpentDone: "Smazáno {count} utracených tokenů.",
   cashuChecking: "Kontroluji token…",
   cashuCheckOk: "Token je v pořádku.",
   pwaUpdateAvailable: "Nová verze Linky je k dispozici",

--- a/apps/web-app/src/i18n/en.ts
+++ b/apps/web-app/src/i18n/en.ts
@@ -538,6 +538,8 @@ export const en = {
   cashuCheckToken: "Check token",
   cashuCheckAllTokens: "Check all",
   cashuCheckIssuedTokens: "Check claimed",
+  cashuDeleteSpentTokens: "Delete spent ({count})",
+  cashuDeleteSpentDone: "Removed {count} spent tokens.",
   cashuChecking: "Checking token…",
   cashuCheckOk: "Token is OK.",
   pwaUpdateAvailable: "A new version of Linky is available",

--- a/apps/web-app/src/pages/CashuTokensPage.tsx
+++ b/apps/web-app/src/pages/CashuTokensPage.tsx
@@ -17,12 +17,15 @@ interface CashuTokensPageProps {
   cashuIsBusy: boolean;
   cashuMeltToMainMintButtonLabel: string | null;
   cashuOwnTokens: readonly CashuTokenListItem[];
+  cashuOwnSpentTokensCount: number;
   cashuIssuedTokens: readonly CashuTokenListItem[];
   checkAllCashuTokensAndDeleteInvalid: () => Promise<void>;
   checkIssuedCashuTokensAndDeleteClaimed: () => Promise<{
     checked: number;
     claimed: ReadonlyArray<{ id: CashuTokenId; amount: number }>;
   }>;
+  deleteSpentCashuTokens: () => Promise<void>;
+  deleteSpentCashuTokensIsBusy: boolean;
   getMintIconUrl: (mint: MintUrlInput) => {
     origin: string | null;
     url: string | null;
@@ -44,8 +47,11 @@ export const CashuTokensPage: FC<CashuTokensPageProps> = ({
   cashuIssuedTokens,
   cashuMeltToMainMintButtonLabel,
   cashuOwnTokens,
+  cashuOwnSpentTokensCount,
   checkAllCashuTokensAndDeleteInvalid,
   checkIssuedCashuTokensAndDeleteClaimed,
+  deleteSpentCashuTokens,
+  deleteSpentCashuTokensIsBusy,
   getMintIconUrl,
   meltLargestForeignMintToMainMint,
   restoreMissingTokens,
@@ -132,6 +138,21 @@ export const CashuTokensPage: FC<CashuTokensPageProps> = ({
             </button>
           </div>
           {renderTokenList(cashuOwnTokens, t("cashuEmpty"))}
+          {cashuOwnSpentTokensCount > 0 ? (
+            <div className="settings-row" style={{ marginTop: 12 }}>
+              <button
+                type="button"
+                className="btn-wide secondary"
+                onClick={() => void deleteSpentCashuTokens()}
+                disabled={cashuIsBusy || deleteSpentCashuTokensIsBusy}
+              >
+                {t("cashuDeleteSpentTokens").replace(
+                  "{count}",
+                  String(cashuOwnSpentTokensCount),
+                )}
+              </button>
+            </div>
+          ) : null}
           {cashuMeltToMainMintButtonLabel ? (
             <div className="settings-row" style={{ marginTop: 12 }}>
               <button


### PR DESCRIPTION
## Summary

Surface a `Delete spent (N)` button on `#wallet/tokens` when the user has tokens in their own list that the mint has marked as definitively spent or invalid (state=`error` with an error message matching `token already spent`, `proofs already spent`, `invalid proof(s)`, `token proofs missing`, or `invalid token`).

Pressing the button marks all matching rows as `isDeleted=true` via Evolu so they disappear from the list and stop syncing forward as live rows on other devices.

## Why

Power users accumulate dead error rows from past failed accepts / spent proofs / mint-rejected swaps. The existing `Check all` only re-runs validation; there was no one-click way to purge rows the mint will never touch again.

## Changes

- `apps/web-app/src/app/lib/cashuTokenState.ts` — new `isCashuTokenDefinitivelySpent` helper. Reuses the same error-message patterns that `useCashuTokenChecks` uses to decide a row is unrecoverable.
- `apps/web-app/src/app/useAppShellComposition.tsx` — `cashuOwnSpentTokens` memo + `deleteSpentCashuTokens` callback that bulk-marks rows `isDeleted=true` on the active cashu owner.
- `apps/web-app/src/pages/CashuTokensPage.tsx` — renders a `Delete spent (N)` button under the own-tokens list when N > 0.
- `apps/web-app/src/i18n/{cs,en}.ts` — `cashuDeleteSpentTokens`, `cashuDeleteSpentDone`.
- Route-prop plumbing through `buildMoneyRouteProps.ts`.

## Test plan

- [x] `bun run check-code` passes.
- [ ] With wallet containing some error-state tokens with "Token already spent" error → button appears with the count.
- [ ] Click → rows disappear from list, status shows "Removed N spent tokens."
- [ ] With no spent tokens → button is not rendered.
- [ ] After delete, other device receives the soft-delete via Evolu sync and removes them from its UI too.