### PR TITLE
fix(evolu): auto-write missing rotation snapshot at boot

### DIFF
--- a/apps/web-app/src/app/hooks/useEvoluContactsOwnerRotation.ts
+++ b/apps/web-app/src/app/hooks/useEvoluContactsOwnerRotation.ts
@@ -1268,6 +1268,90 @@ export const useEvoluContactsOwnerRotation = ({
     transactionsOwnerIndex,
   ]);
 
+  // Bootstrap: ensure each scope has a rotation snapshot in ownerMeta.
+  //
+  // Users who joined before rotation pointers existed (or who never crossed
+  // a rotation threshold post-deploy) have local `*OwnerIndex` values that
+  // diverge across devices silently, because the reconciler above has
+  // nothing in ownerMeta to read. Without a manual `Rotate ... owner` click
+  // from Advanced > Evolu data, devices can stay out of sync indefinitely.
+  //
+  // Write the current local snapshot once per scope per session when no
+  // entry exists. The first device to boot post-deploy seeds ownerMeta with
+  // its index + current row counts. Other devices see the snapshot via
+  // Evolu sync, the reconciler adopts the foreign index (if different),
+  // and the heal callback copies their now-orphan lane data forward.
+  //
+  // If two devices boot at the same time and both write their own snapshot
+  // (different local indices), CRDT LWW picks one and the loser adopts
+  // through the same reconciler + heal path. Same convergence outcome.
+  React.useEffect(() => {
+    if (!isSeedLogin) return;
+    if (!ownerSyncData) return;
+    const metaOwnerId = ownerSyncData.metaOwner.id;
+    const metaOwnerIdStr = String(metaOwnerId).trim();
+    if (!metaOwnerIdStr) return;
+
+    const hasSnapshotForScope = (
+      scope: "contacts" | "messages" | "transactions",
+    ): boolean => {
+      for (const row of ownerMetaRows) {
+        if (readRowOwnerId(row) !== metaOwnerIdStr) continue;
+        const rowScope =
+          typeof row === "object" && row !== null && "scope" in row
+            ? row.scope
+            : null;
+        const rowScopeText =
+          typeof rowScope === "string" ? rowScope.trim() : "";
+        if (rowScopeText !== scope) continue;
+        const decoded = decodeRotationSnapshot(readRowPointerValue(row), scope);
+        if (decoded) return true;
+      }
+      return false;
+    };
+
+    const nowMs = Date.now();
+
+    if (!hasSnapshotForScope("contacts")) {
+      upsertOwnerMetaSnapshot(upsert, metaOwnerId, "contacts", {
+        index: contactsOwnerIndex,
+        baseline: contactsOwnerWriteCount,
+        cashuBaseline: cashuOwnerWriteCount,
+        rotatedAtMs: nowMs,
+      });
+    }
+
+    if (!hasSnapshotForScope("messages")) {
+      upsertOwnerMetaSnapshot(upsert, metaOwnerId, "messages", {
+        index: messagesOwnerIndex,
+        baseline: messagesOwnerWriteCount,
+        cashuBaseline: null,
+        rotatedAtMs: nowMs,
+      });
+    }
+
+    if (!hasSnapshotForScope("transactions")) {
+      upsertOwnerMetaSnapshot(upsert, metaOwnerId, "transactions", {
+        index: transactionsOwnerIndex,
+        baseline: transactionsOwnerWriteCount,
+        cashuBaseline: null,
+        rotatedAtMs: nowMs,
+      });
+    }
+  }, [
+    cashuOwnerWriteCount,
+    contactsOwnerIndex,
+    contactsOwnerWriteCount,
+    isSeedLogin,
+    messagesOwnerIndex,
+    messagesOwnerWriteCount,
+    ownerMetaRows,
+    ownerSyncData,
+    transactionsOwnerIndex,
+    transactionsOwnerWriteCount,
+    upsert,
+  ]);
+
   const rotateContactsAndCashuOwner = React.useCallback(async () => {
     if (rotateContactsOwnerIsBusy) return;
 


### PR DESCRIPTION
## Summary

Follow-up to #126 (now merged). Identical code change to PR #127; recreated as a new branch because #127 auto-closed when its base branch was deleted on merge of #126.

Builds on top of #126's snapshot + heal-on-adopt infrastructure to make sure a snapshot actually gets written to `ownerMeta` even for users who joined before rotation pointers existed.

### Background

Users who joined Linky before rotation pointers (or who never crossed a rotation threshold post-deploy) carry a local `*OwnerIndex` value that the reconciler in `ownerMeta` cannot see, because no snapshot row was ever written. Devices then diverge silently — observed as "delete a token on mobile, desktop still shows it" with both devices on different `contacts-N` / `cashu-N` lanes.

The only recovery was a manual `Rotate contacts owner` click from Advanced > Evolu data, which triggered a snapshot write and convergence via #126's heal path.

### Fix

For each scope (`contacts`, `messages`, `transactions`), check `ownerMeta` at boot and, if no snapshot row exists, write the current local snapshot once:

```
{ index, baseline, cashuBaseline?, rotatedAtMs }
```

- First device to boot post-deploy seeds `ownerMeta`.
- Other devices see the snapshot via Evolu sync; the reconciler from #126 adopts the index if it differs, and the heal callback re-upserts orphan lane data into the new shared lane.
- If two devices boot in the same window and write competing snapshots (different local indices), CRDT LWW picks one and the loser adopts through the same reconciler + heal path. Same convergence outcome.

## Test plan

- [x] `bun run check-code` passes.
- [x] `rotationSnapshot.test.ts` (16 tests) passes.
- [ ] On a device with no `contacts` row in `ownerMeta` (visible in `#evolu-data` > ownerMeta tab), wait for app boot. Snapshot row appears within a render.
- [ ] Two devices with diverged local indices come online — both write their own snapshot, CRDT settles, reconciler + heal converge to a shared lane.
- [ ] Fresh onboarding: snapshot rows for all three scopes appear immediately after first boot.

Replaces #127 (auto-closed when `fix/owner-rotation-snapshot-sync` was deleted on merge of #126).