### PR TITLE
fix(cashu): wipe deterministic counters on cashu seed change

### DIFF
--- a/apps/web-app/src/app/hooks/cashu/useRestoreMissingTokens.ts
+++ b/apps/web-app/src/app/hooks/cashu/useRestoreMissingTokens.ts
@@ -324,19 +324,18 @@ export const useRestoreMissingTokens = ({
               //   e (2nd)  = positions per HTTP /v1/restore request
               //   stops after ceil(t / e) consecutive empty rounds
               //
-              // The library defaults `(300, 100)` mean only 3 empty rounds
-              // (~300 positions) before giving up. That breaks restore for
-              // any wallet whose deterministic counter is stale relative to
-              // the actual signed range — e.g., after a cashu mnemonic
-              // change leaves the counter at N but no proofs at 0..N-1 with
-              // the new seed. The scan dies long before reaching the
-              // freshly-minted proofs at counter N.
-              //
-              // 20000 / 200 = 100 empty rounds → ~20000 positions tolerated,
-              // 200 outputs per request stays well under cashu.cz's payload
-              // limit (>~1000 hits HTTP 422 on cashu.cz).
+              // The cashu-ts default `(300, 100)` is fine for healthy
+              // wallets: any consecutive activity keeps the scan going and
+              // a fully empty keyset finishes in ~1-2 s. We deliberately
+              // do NOT bump this further to chase very stale counters —
+              // those should be prevented at the source via
+              // `wipeCashuDeterministicState()` whenever the cashu BIP-85
+              // mnemonic changes. Widening the budget here would cost
+              // every user 5-50 s of restore wait just to rescue a handful
+              // of pre-fix wallets that can also recover by re-onboarding
+              // (which now wipes stale counters).
               const batchRestore = async (counterStart: number) =>
-                await wallet.batchRestore(20000, 200, counterStart, keysetId);
+                await wallet.batchRestore(300, 100, counterStart, keysetId);
 
               let restored: {
                 lastCounterWithSignature?: number;

--- a/apps/web-app/src/app/hooks/cashu/useRestoreMissingTokens.ts
+++ b/apps/web-app/src/app/hooks/cashu/useRestoreMissingTokens.ts
@@ -319,8 +319,24 @@ export const useRestoreMissingTokens = ({
               );
               const start = Math.max(0, highWater - restoreRescanWindow);
 
+              // cashu-ts batchRestore arg semantics (see source):
+              //   t (1st)  = total gap budget in counter positions
+              //   e (2nd)  = positions per HTTP /v1/restore request
+              //   stops after ceil(t / e) consecutive empty rounds
+              //
+              // The library defaults `(300, 100)` mean only 3 empty rounds
+              // (~300 positions) before giving up. That breaks restore for
+              // any wallet whose deterministic counter is stale relative to
+              // the actual signed range — e.g., after a cashu mnemonic
+              // change leaves the counter at N but no proofs at 0..N-1 with
+              // the new seed. The scan dies long before reaching the
+              // freshly-minted proofs at counter N.
+              //
+              // 20000 / 200 = 100 empty rounds → ~20000 positions tolerated,
+              // 200 outputs per request stays well under cashu.cz's payload
+              // limit (>~1000 hits HTTP 422 on cashu.cz).
               const batchRestore = async (counterStart: number) =>
-                await wallet.batchRestore(300, 100, counterStart, keysetId);
+                await wallet.batchRestore(20000, 200, counterStart, keysetId);
 
               let restored: {
                 lastCounterWithSignature?: number;

--- a/apps/web-app/src/platform/identitySecrets.ts
+++ b/apps/web-app/src/platform/identitySecrets.ts
@@ -1,4 +1,5 @@
 import { INITIAL_MNEMONIC_STORAGE_KEY } from "../mnemonic";
+import { wipeCashuDeterministicState } from "../utils/cashuDeterministic";
 import {
   CASHU_BIP85_MNEMONIC_STORAGE_KEY,
   NOSTR_IDENTITY_SOURCE_STORAGE_KEY,
@@ -15,6 +16,27 @@ import {
   removeStoredSecret,
   writeStoredSecret,
 } from "./secretStorage";
+
+// Per-mint/keyset deterministic counters live in localStorage under
+// `linky.cashu.detCounter.v1:*` and are bound to whichever cashu BIP-85
+// mnemonic was active when they were last bumped. When the mnemonic itself
+// changes (re-onboarding, paste-nsec then derive back, restore-from-different
+// SLIP-39, ...) the counters become stale — they still point past the new
+// seed's actual signed range at the mint, so future mints start at an
+// arbitrary offset and NUT-09 restore from 0 silently gives up before
+// reaching them. Wipe whenever we're about to write a *different* mnemonic.
+const wipeCashuStateIfMnemonicChanged = async (
+  nextCashuMnemonic: string,
+): Promise<void> => {
+  const next = String(nextCashuMnemonic ?? "").trim();
+  if (!next) return;
+  const current = (
+    await readStoredSecret(CASHU_BIP85_MNEMONIC_STORAGE_KEY)
+  )?.trim();
+  if (!current) return; // no prior state to wipe
+  if (current === next) return; // unchanged
+  wipeCashuDeterministicState();
+};
 
 interface PersistIdentitySecretsParams {
   appMnemonic: string;
@@ -46,6 +68,7 @@ export const readStoredCashuMnemonic = async (): Promise<string | null> => {
 export const writeStoredCashuMnemonic = async (
   cashuMnemonic: string,
 ): Promise<void> => {
+  await wipeCashuStateIfMnemonicChanged(cashuMnemonic);
   await writeStoredSecret(CASHU_BIP85_MNEMONIC_STORAGE_KEY, cashuMnemonic);
 };
 
@@ -57,6 +80,8 @@ export const persistIdentitySecrets = async ({
   slip39Seed,
   switchedAtSec,
 }: PersistIdentitySecretsParams): Promise<void> => {
+  await wipeCashuStateIfMnemonicChanged(cashuMnemonic);
+
   await Promise.all([
     writeStoredSecret(NOSTR_NSEC_STORAGE_KEY, nsec),
     writeStoredSecret(NOSTR_SLIP39_SEED_STORAGE_KEY, slip39Seed),
@@ -106,6 +131,11 @@ export const persistSyncedActiveNostrIdentity = async ({
 };
 
 export const clearIdentitySecrets = async (): Promise<void> => {
+  // The deterministic counters belong to the seed that's being cleared. If
+  // the user logs in again with a different seed they'd otherwise inherit
+  // stale offsets that break NUT-09 restore.
+  wipeCashuDeterministicState();
+
   await Promise.all([
     removeStoredSecret(NOSTR_NSEC_STORAGE_KEY),
     removeStoredSecret(NOSTR_SLIP39_SEED_STORAGE_KEY),

--- a/apps/web-app/src/utils/cashuDeterministic.ts
+++ b/apps/web-app/src/utils/cashuDeterministic.ts
@@ -43,6 +43,42 @@ const CASHU_COUNTER_STORAGE_PREFIX = "linky.cashu.detCounter.v1";
 const CASHU_RESTORE_CURSOR_STORAGE_PREFIX = "linky.cashu.restoreCursor.v1";
 const CASHU_COUNTER_LOCK_PREFIX = "linky.cashu.detCounterLock.v1";
 
+// All localStorage prefixes whose state is tied to a specific cashu BIP-85
+// mnemonic. If the mnemonic changes, every entry under these prefixes refers
+// to a derivation tree the new mnemonic cannot reproduce — counters become
+// stale offsets, restore cursors point at empty regions, and any new mint
+// starts at a counter past the new seed's actual signed range. Wipe these
+// whenever the cashu mnemonic is replaced with a different value.
+const CASHU_SEED_BOUND_PREFIXES = [
+  CASHU_COUNTER_STORAGE_PREFIX,
+  CASHU_RESTORE_CURSOR_STORAGE_PREFIX,
+  CASHU_COUNTER_LOCK_PREFIX,
+] as const;
+
+export const wipeCashuDeterministicState = (): void => {
+  try {
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+      if (CASHU_SEED_BOUND_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+        keysToRemove.push(key);
+      }
+    }
+    for (const key of keysToRemove) {
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        // ignore individual key failure
+      }
+    }
+  } catch {
+    // ignore storage unavailability
+  }
+  // Drop the in-memory queue too; the locks were keyed to the previous seed.
+  counterLocks.clear();
+};
+
 // In-memory per-keyset queue to ensure we never reuse the same deterministic
 // output counter range due to overlapping async mint operations.
 // Note: this does not coordinate across browser tabs/windows.


### PR DESCRIPTION
## Summary

Root-cause fix for NUT-09 restore failing after the cashu BIP-85 mnemonic gets replaced.

### Problem

`linky.cashu.detCounter.v1:<mint>|<unit>|<keysetId>` is bumped after every successful mint / swap / melt and represents \"how far the wallet has walked the deterministic derivation tree for that mint+keyset.\" The counter is keyed by mint + unit + keyset id only — **not** by mnemonic. When the cashu BIP-85 mnemonic is replaced (re-onboarding into a different SLIP-39, paste-nsec + derive back, restore-from-backup) the counter for the previous seed is inherited by the new one, even though the new seed's derivation produces a completely different blinded-output sequence.

End-to-end repro that motivated this PR:

1. Wallet starts on seed A. Counter on `cashu.cz | sat | 01ba87f253…` advances to 1134.
2. Cashu mnemonic gets overwritten with seed B (no counter reset).
3. User mints 100 sat. `mintProofs(counter: 1134)` derives blinded outputs from **seed B** at counters 1134-1136. Mint signs. Counter → 1137.
4. User deletes the token, runs Restore.
5. `wallet.batchRestore(300, 100, 0, keysetId)` scans from 0 with seed B. Counters 0-1133 are unsigned (mint has signatures there, but from seed A — different blinded outputs). After 3 empty rounds (~counter 300) the scan gives up.
6. Result: `No missing tokens found`. The proofs are intact — `wallet.restore(1134, 10, keysetId)` finds them in one request — but restore never reaches that counter.

Verified that the proofs are reachable when starting at a counter close to 1134:

```js
// All three find the token's secrets at counters 1134-1136:
await wallet.restore(1134, 10, keysetId);                  // direct, 1 request
await wallet.batchRestore(2000, 200, 0, keysetId);         // wider gap
await wallet.batchRestore(20000, 200, 0, keysetId);        // very wide gap
// Linky's call silently empty:
await wallet.batchRestore(300, 100, 0, keysetId);          // proofs: 0
```

### Fix

Wipe the deterministic counter / restoreCursor / counterLock storage **at the source** whenever the cashu BIP-85 mnemonic about to be written differs from what's currently stored. Three writers hit:

- `writeStoredCashuMnemonic` (auto-backfill effect in `useProfileAuthDomain.ts`).
- `persistIdentitySecrets` (every onboarding / paste-nsec / derive-back path).
- `clearIdentitySecrets` (logout — unconditional wipe, since the next login may use any seed).

`wipeCashuDeterministicState()` in `cashuDeterministic.ts` is a small helper that iterates `localStorage`, removes every key prefixed with the three seed-bound storage keys, and clears the in-memory counter-lock map.

No-op when the new mnemonic matches the stored one, so re-login with the same seed (or the auto-backfill effect kicking in at boot) doesn't churn counters.

NUT-09 restore stays on the cashu-ts default `batchRestore(300, 100, …)` gap budget. Bumping it would cost every user 5-50 s of wait time on a fresh wallet, just to rescue the handful of pre-fix wallets whose counters are already stale. Those users can re-onboard (the wipe triggers) or re-import the token text directly via `#wallet/token/new` (the proofs are intact on the mint, only the deterministic derivation is misaligned).

## Test plan

- [x] `bun run check-code` passes.
- [ ] Onboard with SLIP-39 A. Mint some sats. Verify `linky.cashu.detCounter.v1:*` advances.
- [ ] Re-onboard with SLIP-39 B (different seed). Verify all `linky.cashu.detCounter.v1:*` keys are gone.
- [ ] Re-login with SLIP-39 A again (same seed). Verify the counters are NOT wiped (no churn on same-seed login).
- [ ] Logout. Verify the counters are gone.
- [ ] Mint → delete → restore roundtrip on a wallet that's been through a seed change: restore finds the deleted token.

## Out of scope

- Recovering legacy wallets that already had stale counters before this fix shipped. They can re-onboard (triggers wipe) or re-import token text manually.
- Underlying cashu-ts behavior: the library's `batchRestore` gives up after 3 empty rounds by default, which is fine when counters are healthy but unforgiving when they aren't. We rely on the wipe to keep counters healthy; not changing the library.